### PR TITLE
feat(core): Initial checked-in workflow Schema

### DIFF
--- a/schemas/flow.json
+++ b/schemas/flow.json
@@ -1,0 +1,484 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Flow",
+  "description": "A workflow consisting of a sequence of steps and their outputs.\n\nA flow represents a complete workflow that can be executed. It contains:\n- A sequence of steps to execute\n- Named outputs that can reference step outputs\n\nFlows should not be cloned. They should generally be stored and passed as a\nreference or inside an `Arc`.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the flow.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "description": {
+      "description": "The description of the flow.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "version": {
+      "description": "The version of the flow.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "inputSchema": {
+      "description": "The input schema of the flow.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Schema"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "outputSchema": {
+      "description": "The output schema of the flow.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Schema"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "steps": {
+      "description": "The steps to execute for the flow.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Step"
+      }
+    },
+    "output": {
+      "description": "The outputs of the flow, mapping output names to their values.",
+      "$ref": "#/$defs/Value"
+    },
+    "test": {
+      "description": "Test configuration for the flow.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TestConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "examples": {
+      "description": "Example inputs for the workflow that can be used for testing and UI dropdowns.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ExampleInput"
+      }
+    }
+  },
+  "$defs": {
+    "Schema": {
+      "$ref": "https://json-schema.org/draft/2020-12/schema"
+    },
+    "Step": {
+      "description": "A step in a workflow that executes a component with specific arguments.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Identifier for the step",
+          "type": "string"
+        },
+        "component": {
+          "description": "The component to execute in this step",
+          "$ref": "#/$defs/Component"
+        },
+        "inputSchema": {
+          "description": "The input schema for this step.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "outputSchema": {
+          "description": "The output schema for this step.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Schema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "skipIf": {
+          "description": "If set and the referenced value is truthy, this step will be skipped.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "onError": {
+          "$ref": "#/$defs/ErrorAction"
+        },
+        "input": {
+          "description": "Arguments to pass to the component for this step",
+          "$ref": "#/$defs/Value"
+        }
+      },
+      "required": [
+        "id",
+        "component"
+      ]
+    },
+    "Component": {
+      "description": "Identifies a specific plugin and atomic functionality to execute.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "string",
+          "format": "uri"
+        }
+      ]
+    },
+    "Expr": {
+      "description": "An expression that can be either a literal value or a template expression.",
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "$from": {
+              "description": "The source of the reference.",
+              "$ref": "#/$defs/BaseRef"
+            },
+            "path": {
+              "description": "JSON pointer expression to apply to the referenced value.\n\nMay be omitted to use the entire value.\nMay also be a bare field name (without the leading `/`) if\nthe referenced value is an object.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "onSkip": {
+              "$ref": "#/$defs/SkipAction"
+            }
+          },
+          "required": [
+            "$from"
+          ]
+        },
+        {
+          "$ref": "#/$defs/Value"
+        }
+      ]
+    },
+    "BaseRef": {
+      "description": "An expression that can be either a literal value or a template expression.",
+      "anyOf": [
+        {
+          "description": "Reference properties of the workflow.",
+          "type": "object",
+          "properties": {
+            "workflow": {
+              "$ref": "#/$defs/WorkflowRef"
+            }
+          },
+          "required": [
+            "workflow"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "description": "Reference the output of a step.",
+          "type": "object",
+          "properties": {
+            "step": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "step"
+          ]
+        }
+      ]
+    },
+    "WorkflowRef": {
+      "type": "string",
+      "enum": [
+        "input"
+      ]
+    },
+    "SkipAction": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "skip"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Value"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "action": {
+              "type": "string",
+              "const": "useDefault"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      ]
+    },
+    "Value": {
+      "description": "Any JSON value (object, array, string, number, boolean, or null)"
+    },
+    "ErrorAction": {
+      "oneOf": [
+        {
+          "description": "If the step fails, the flow will fail.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "fail"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "description": "If the step fails, mark it as skipped. This allows down-stream steps to handle the skipped step.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "skip"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "description": "If the step fails, use the `defaultValue` instead.",
+          "type": "object",
+          "properties": {
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Value"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "action": {
+              "type": "string",
+              "const": "useDefault"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        },
+        {
+          "description": "If the step fails, retry it.",
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "const": "retry"
+            }
+          },
+          "required": [
+            "action"
+          ]
+        }
+      ]
+    },
+    "TestConfig": {
+      "description": "Configuration for testing a workflow.",
+      "type": "object",
+      "properties": {
+        "stepflowConfig": {
+          "description": "Stepflow configuration specific to tests."
+        },
+        "cases": {
+          "description": "Test cases for the workflow.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TestCase"
+          }
+        }
+      }
+    },
+    "TestCase": {
+      "description": "A single test case for a workflow.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Unique identifier for the test case.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description of what this test case verifies.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "input": {
+          "description": "Input data for the workflow in this test case.",
+          "$ref": "#/$defs/Value"
+        },
+        "output": {
+          "description": "Expected output from the workflow for this test case.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FlowResult"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "input"
+      ]
+    },
+    "FlowResult": {
+      "description": "The results of a step execution.",
+      "oneOf": [
+        {
+          "description": "The step execution was successful.",
+          "type": "object",
+          "properties": {
+            "result": {
+              "$ref": "#/$defs/Value"
+            },
+            "outcome": {
+              "type": "string",
+              "const": "success"
+            }
+          },
+          "required": [
+            "outcome",
+            "result"
+          ]
+        },
+        {
+          "description": "The step was skipped.",
+          "type": "object",
+          "properties": {
+            "outcome": {
+              "type": "string",
+              "const": "skipped"
+            }
+          },
+          "required": [
+            "outcome"
+          ]
+        },
+        {
+          "description": "The step failed with the given error.",
+          "type": "object",
+          "properties": {
+            "error": {
+              "$ref": "#/$defs/FlowError"
+            },
+            "outcome": {
+              "type": "string",
+              "const": "failed"
+            }
+          },
+          "required": [
+            "outcome",
+            "error"
+          ]
+        }
+      ]
+    },
+    "FlowError": {
+      "description": "An error reported from within a flow or step.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "message": {
+          "type": "string"
+        },
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "ExampleInput": {
+      "description": "An example input for a workflow that can be used in UI dropdowns.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the example input for display purposes.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description of what this example demonstrates.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "input": {
+          "description": "The input data for this example.",
+          "$ref": "#/$defs/Value"
+        }
+      },
+      "required": [
+        "name",
+        "input"
+      ]
+    }
+  }
+}

--- a/stepflow-rs/crates/stepflow-core/src/schema.rs
+++ b/stepflow-rs/crates/stepflow-core/src/schema.rs
@@ -18,9 +18,21 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Type alias for a shared schema reference.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct SchemaRef(Arc<Schema>);
+
+impl JsonSchema for SchemaRef {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "Schema".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+             "$ref": _generator.settings().meta_schema,
+        })
+    }
+}
 
 impl From<Schema> for SchemaRef {
     fn from(schema: Schema) -> Self {

--- a/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
@@ -498,10 +498,7 @@ mod schema_tests {
         let generated_json = serde_json::to_value(&generated_schema)
             .expect("Failed to convert generated schema to JSON");
 
-        let flow_schema_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../../schemas/flow.json"
-        );
+        let flow_schema_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../schemas/flow.json");
 
         if env::var("STEPFLOW_OVERWRITE_SCHEMA").is_ok() {
             // Create directory and write schema
@@ -517,23 +514,27 @@ mod schema_tests {
             // Compare with existing schema
             match std::fs::read_to_string(flow_schema_path) {
                 Ok(flow_schema_str) => {
-                    let flow_schema: serde_json::Value = 
-                        serde_json::from_str(&flow_schema_str)
-                            .expect("Failed to parse flow schema JSON");
-                    
+                    let flow_schema: serde_json::Value = serde_json::from_str(&flow_schema_str)
+                        .expect("Failed to parse flow schema JSON");
+
                     let generated_schema_str = serde_json::to_string_pretty(&generated_json)
                         .expect("Failed to serialize generated schema");
                     let expected_schema_str = serde_json::to_string_pretty(&flow_schema)
                         .expect("Failed to serialize expected schema");
 
-                    similar_asserts::assert_eq!(generated_schema_str, expected_schema_str, 
+                    similar_asserts::assert_eq!(
+                        generated_schema_str,
+                        expected_schema_str,
                         "Generated schema does not match the reference schema at {}. \
                          Run with STEPFLOW_OVERWRITE_SCHEMA=1 to update the reference schema.",
-                        flow_schema_path);
+                        flow_schema_path
+                    );
                 }
                 Err(_) => {
-                    panic!("Flow schema file not found at {flow_schema_path}. \
-                           Run with STEPFLOW_OVERWRITE_SCHEMA=1 to create it.");
+                    panic!(
+                        "Flow schema file not found at {flow_schema_path}. \
+                           Run with STEPFLOW_OVERWRITE_SCHEMA=1 to create it."
+                    );
                 }
             }
         }


### PR DESCRIPTION
This initial schema has some issues -- specifically, it doesn't reflect the structure of values that can reference earlier steps, nor indicate where these "value templates" are possible. I'm planning to update the code and schema to make this clearer, but this is a solid first step.