### PR TITLE
feat: Support `.` and `[...]` in paths

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,9 +76,10 @@ jobs:
 
       - name: Add labels
         if: steps.determine_labels.outputs.labels != ''
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: ${{ steps.determine_labels.outputs.labels }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "${{ steps.determine_labels.outputs.labels }}"
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # When any previous step fails, the workflow would stop. By adding this

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,8 @@ jobs:
     name: Validate PR
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
+      issues: write # Required for adding labels
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,28 @@ pnpm lint
 pnpm type-check
 ```
 
+### Schema Generation
+When making changes to core types, you may need to regenerate schemas and derived code:
+
+```bash
+# Regenerate JSON schemas from Rust types (run from stepflow-rs directory)
+cd stepflow-rs
+STEPFLOW_OVERWRITE_SCHEMA=1 cargo test
+
+# Regenerate Python types from updated schemas
+cd sdks/python
+uv run python generate.py
+
+# Check if Python types are up to date without regenerating
+cd sdks/python
+uv run python generate.py --check
+```
+
+**Important**: Always regenerate schemas after modifying the workflow and protocol types (in `stepflow-core` and `stepflow-protocol`, respectively). The schema files are used by:
+- Python SDK type generation
+- Documentation and examples
+- API validation in server components
+
 ## Project Architecture
 
 Step Flow is an execution engine for AI workflows, built in Rust. The project is structured as a workspace with multiple crates, each serving a specific purpose.

--- a/schemas/flow.json
+++ b/schemas/flow.json
@@ -167,11 +167,8 @@
               "$ref": "#/$defs/BaseRef"
             },
             "path": {
-              "description": "JSON pointer expression to apply to the referenced value.\n\nMay be omitted to use the entire value.\nMay also be a bare field name (without the leading `/`) if\nthe referenced value is an object.",
-              "type": [
-                "string",
-                "null"
-              ]
+              "description": "JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object.",
+              "$ref": "#/$defs/JsonPath"
             },
             "onSkip": {
               "$ref": "#/$defs/SkipAction"
@@ -238,6 +235,17 @@
       "type": "string",
       "enum": [
         "input"
+      ]
+    },
+    "JsonPath": {
+      "description": "JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.",
+      "type": "string",
+      "examples": [
+        "field",
+        "$.field",
+        "$[\"field\"]",
+        "$[0]",
+        "$.field[0].nested"
       ]
     },
     "SkipAction": {

--- a/sdks/python/src/stepflow_sdk/generated_flow.py
+++ b/sdks/python/src/stepflow_sdk/generated_flow.py
@@ -45,6 +45,15 @@ class WorkflowRef(Enum):
     input = 'input'
 
 
+JsonPath = Annotated[
+    str,
+    Meta(
+        description='JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.',
+        examples=['field', '$.field', '$["field"]', '$[0]', '$.field[0].nested'],
+    ),
+]
+
+
 class OnSkipSkip(Struct, kw_only=True):
     action: Literal['skip']
 
@@ -143,9 +152,9 @@ class Reference(Struct, kw_only=True):
     )
     path: (
         Annotated[
-            str | None,
+            JsonPath,
             Meta(
-                description='JSON pointer expression to apply to the referenced value.\n\nMay be omitted to use the entire value.\nMay also be a bare field name (without the leading `/`) if\nthe referenced value is an object.'
+                description='JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object.'
             ),
         ]
         | None

--- a/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
+++ b/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
@@ -173,7 +173,7 @@ impl<L: ValueLoader> ValueResolver<L> {
             match base_result {
                 FlowResult::Success { result } => {
                     tracing::debug!("Resolving path '{}' on value: {:?}", path, result.as_ref());
-                    if let Some(sub_value) = result.path(path) {
+                    if let Some(sub_value) = result.resolve_json_path(path) {
                         tracing::debug!("Path '{}' resolved to: {:?}", path, sub_value.as_ref());
                         FlowResult::Success { result: sub_value }
                     } else {
@@ -287,7 +287,7 @@ impl<L: ValueLoader> ValueResolver<L> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow::{Component, ErrorAction, Step};
+    use crate::workflow::{Component, ErrorAction, JsonPath, Step};
     use async_trait::async_trait;
     use serde_json::json;
 
@@ -414,7 +414,7 @@ mod tests {
         let resolver = ValueResolver::new(run_id, workflow_input, loader, flow);
 
         // Test resolving ValueTemplate - create a template with an expression by deserializing from JSON
-        let template = ValueTemplate::workflow_input(Some("name"));
+        let template = ValueTemplate::workflow_input(JsonPath::from("name"));
         let resolved = resolver.resolve_template(&template).await.unwrap();
         match resolved {
             FlowResult::Success { result } => {

--- a/stepflow-rs/crates/stepflow-core/src/workflow.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow.rs
@@ -14,12 +14,14 @@
 mod component;
 mod expr;
 mod flow;
+mod json_path;
 mod step;
 mod step_id;
 
 pub use component::*;
 pub use expr::*;
 pub use flow::*;
+pub use json_path::*;
 pub use step::*;
 pub use step_id::*;
 

--- a/stepflow-rs/crates/stepflow-core/src/workflow/expr.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/expr.rs
@@ -14,8 +14,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::workflow::{json_path::JsonPath, ValueRef};
-
+use crate::workflow::{ValueRef, json_path::JsonPath};
 
 /// An expression that can be either a literal value or a template expression.
 #[derive(
@@ -319,7 +318,6 @@ mod tests {
             }
         );
     }
-
 
     #[test]
     fn test_expr_with_skip_action_from_yaml() {

--- a/stepflow-rs/crates/stepflow-core/src/workflow/json_path.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/json_path.rs
@@ -1,0 +1,347 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+// See the NOTICE file distributed with this work for additional information regarding copyright
+// ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the License.  You may obtain a
+// copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations under
+// the License.
+
+use schemars::JsonSchema;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+/// A single part of a JSON path.
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub enum PathPart {
+    /// Access a field by name
+    Field(String),
+    /// Access an array element by index
+    Index(usize),
+    /// Access an element by string key (for arrays that can be indexed by string)
+    IndexStr(String),
+}
+
+/// A JSON path represented as a sequence of path parts.
+/// This type serializes and deserializes as a string but internally
+/// maintains a structured representation for efficient processing.
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub struct JsonPath(Vec<PathPart>);
+
+impl JsonPath {
+    /// Create a new empty path
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Create a path from a vector of parts
+    pub fn from_parts(parts: Vec<PathPart>) -> Self {
+        Self(parts)
+    }
+
+    /// Get the parts of the path
+    pub fn parts(&self) -> &[PathPart] {
+        &self.0
+    }
+
+    /// Check if the path is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn outer_field(&self) -> Option<&str> {
+        match self.0.first() {
+            Some(PathPart::Field(name)) => Some(name),
+            Some(PathPart::IndexStr(name)) => Some(name),
+            _ => None,
+        }
+    }
+
+    /// Parse a string path into a JsonPath
+    pub fn parse(s: &str) -> Result<Self, String> {
+        if s.is_empty() {
+            return Ok(Self::new());
+        }
+
+        let s = match s.trim().strip_prefix("$") {
+            Some(s) => s,
+            None => {
+                // If it doesn't start with $, treat it as a bare field name
+                return Ok(Self::from_parts(vec![PathPart::Field(s.to_string())]));
+            }
+        };
+
+        let mut parts = Vec::new();
+        let mut chars = s.chars().peekable();
+
+        while let Some(ch) = chars.next() {
+            match ch {
+                '[' => {
+                    let mut bracket_content = String::new();
+                    let mut found_end = false;
+
+                    for ch in chars.by_ref() {
+                        if ch == ']' {
+                            found_end = true;
+                            break;
+                        }
+                        bracket_content.push(ch);
+                    }
+
+                    if !found_end {
+                        return Err("Unclosed bracket '[' in path".to_string());
+                    }
+
+                    let bracket_content = bracket_content.trim();
+
+                    // Check if it's a quoted string
+                    if (bracket_content.starts_with('"') && bracket_content.ends_with('"'))
+                        || (bracket_content.starts_with('\'') && bracket_content.ends_with('\''))
+                    {
+                        let field_name = &bracket_content[1..bracket_content.len() - 1];
+                        parts.push(PathPart::Field(field_name.to_string()));
+                    } else if let Ok(index) = bracket_content.parse::<usize>() {
+                        parts.push(PathPart::Index(index));
+                    } else {
+                        return Err(format!(
+                            "Invalid index '{bracket_content}' in JSON path. Expected a number or a quoted string."
+                        ));
+                    }
+                }
+                '.' => {
+                    let mut field_name = String::new();
+
+                    while let Some(&ch) = chars.peek() {
+                        if ch == '[' || ch == '.' {
+                            break;
+                        }
+                        field_name.push(chars.next().unwrap());
+                    }
+
+                    if !field_name.is_empty() {
+                        parts.push(PathPart::Field(field_name));
+                    }
+                }
+                _ => {
+                    return Err(format!(
+                        "Invalid character '{ch}' in JSON path after $ or ']'. Expected '.' or '['"
+                    ));
+                }
+            }
+        }
+
+        Ok(Self::from_parts(parts))
+    }
+
+    /// Convert the path back to string representation
+    fn as_string(&self) -> String {
+        let mut result = String::from("$");
+
+        for part in &self.0 {
+            match part {
+                PathPart::Field(name) => {
+                    result.push_str(&format!(".{name}"));
+                }
+                PathPart::Index(idx) => {
+                    result.push_str(&format!("[{idx}]"));
+                }
+                PathPart::IndexStr(s) => {
+                    result.push_str(&format!("[\"{s}\"]"));
+                }
+            }
+        }
+
+        result
+    }
+}
+
+impl Default for JsonPath {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for JsonPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_string())
+    }
+}
+
+impl Serialize for JsonPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct JsonPathVisitor;
+
+        impl<'de> Visitor<'de> for JsonPathVisitor {
+            type Value = JsonPath;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a JSON path string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                JsonPath::parse(value).map_err(de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(JsonPathVisitor)
+    }
+}
+
+impl JsonSchema for JsonPath {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "JsonPath".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "string",
+            "description": "JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.",
+            "examples": ["field", "$.field", "$[\"field\"]", "$[0]", "$.field[0].nested"]
+        })
+    }
+}
+
+impl utoipa::PartialSchema for JsonPath {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        // Use a simple string schema
+        utoipa::openapi::RefOr::T(utoipa::openapi::Schema::AllOf(
+            utoipa::openapi::AllOfBuilder::new()
+                .description(Some("JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object."))
+                .build()
+        ))
+    }
+}
+
+impl utoipa::ToSchema for JsonPath {}
+
+impl From<String> for JsonPath {
+    fn from(s: String) -> Self {
+        Self::parse(&s).unwrap_or_default()
+    }
+}
+
+impl From<&str> for JsonPath {
+    fn from(s: &str) -> Self {
+        Self::parse(s).unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_json_path_parsing() {
+        // Test backwards compatibility - bare field name
+        let path = JsonPath::parse("field").unwrap();
+        assert_eq!(path.parts(), &[PathPart::Field("field".to_string())]);
+        assert_eq!(path.to_string(), "$.field");
+
+        // Test $ prefix field access
+        let path = JsonPath::parse("$[\"field\"]").unwrap();
+        assert_eq!(path.parts(), &[PathPart::Field("field".to_string())]);
+        assert_eq!(path.to_string(), "$.field");
+
+        // Test dot notation
+        let path = JsonPath::parse("$.field").unwrap();
+        assert_eq!(path.parts(), &[PathPart::Field("field".to_string())]);
+        assert_eq!(path.to_string(), "$.field");
+
+        // Test array index
+        let path = JsonPath::parse("$[0]").unwrap();
+        assert_eq!(path.parts(), &[PathPart::Index(0)]);
+        assert_eq!(path.to_string(), "$[0]");
+
+        // Test complex path
+        let path = JsonPath::parse("$.field[0].nested").unwrap();
+        assert_eq!(
+            path.parts(),
+            &[
+                PathPart::Field("field".to_string()),
+                PathPart::Index(0),
+                PathPart::Field("nested".to_string())
+            ]
+        );
+        assert_eq!(path.to_string(), "$.field[0].nested");
+
+        // Test empty path
+        let path = JsonPath::parse("").unwrap();
+        assert!(path.is_empty());
+        assert_eq!(path.to_string(), "$");
+    }
+    #[test]
+
+    fn test_json_path_invalid_syntax() {
+        // Invalid -- missing `.` or `[` after `$`
+        assert_eq!(
+            JsonPath::parse("$field").unwrap_err(),
+            "Invalid character 'f' in JSON path after $ or ']'. Expected '.' or '['"
+        );
+
+        // Missing `.` or `[` after `]`
+        assert_eq!(
+            JsonPath::parse("$[0]field").unwrap_err(),
+            "Invalid character 'f' in JSON path after $ or ']'. Expected '.' or '['"
+        );
+
+        // Unterminated string
+        assert_eq!(
+            JsonPath::parse("$[\"hello").unwrap_err(),
+            "Unclosed bracket '[' in path"
+        );
+        // Unterminated square-brackets (string key)
+        assert_eq!(
+            JsonPath::parse("$[\"hello\"").unwrap_err(),
+            "Unclosed bracket '[' in path"
+        );
+        // Unterminated square-brackets (numeric key)
+        assert_eq!(
+            JsonPath::parse("$[5").unwrap_err(),
+            "Unclosed bracket '[' in path"
+        );
+        // Invalid non-digit in square brackets
+        assert_eq!(
+            JsonPath::parse("$[hello]").unwrap_err(),
+            "Invalid index 'hello' in JSON path. Expected a number or a quoted string."
+        );
+    }
+
+    #[test]
+    fn test_json_path_serialization() {
+        // Test that single field serializes with $ notation (changed from backwards compatibility)
+        let path = JsonPath::from("field");
+        let serialized = serde_json::to_string(&path).unwrap();
+        assert_eq!(serialized, "\"$.field\"");
+
+        // Test that complex path serializes with $ notation
+        let path = JsonPath::parse("$.field[0]").unwrap();
+        let serialized = serde_json::to_string(&path).unwrap();
+        assert_eq!(serialized, "\"$.field[0]\"");
+
+        // Test round-trip
+        let original = JsonPath::parse("$.items[0].name").unwrap();
+        let serialized = serde_json::to_string(&original).unwrap();
+        let deserialized: JsonPath = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(original, deserialized);
+    }
+}


### PR DESCRIPTION
This allows a subset of JSON path expressions to be used as paths in StepFlow. We could extend this to support more of JSON path as needed.