### PR TITLE
ci: Setup CI for python

### DIFF
--- a/.github/actions/docs-checks/action.yml
+++ b/.github/actions/docs-checks/action.yml
@@ -1,0 +1,37 @@
+name: 'Documentation Checks'
+description: 'Build and validate documentation to ensure it compiles correctly'
+
+inputs:
+  pnpm-version:
+    description: 'pnpm version to use'
+    required: false
+    default: '10.4.1'
+  node-version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
+        cache-dependency-path: docs/pnpm-lock.yaml
+
+    - name: Install documentation dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+      working-directory: docs
+
+    - name: Build documentation
+      shell: bash
+      run: pnpm build
+      working-directory: docs

--- a/.github/actions/python-checks/action.yml
+++ b/.github/actions/python-checks/action.yml
@@ -1,0 +1,53 @@
+name: 'Python SDK Checks'
+description: 'Run Python SDK tests and validate generated types'
+
+inputs:
+  uv-version:
+    description: 'uv version to install'
+    required: false
+    default: '0.7.5'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: ${{ inputs.uv-version }}
+        enable-cache: true
+
+    - name: Set up Python
+      shell: bash
+      run: uv python install
+      working-directory: sdks/python
+
+    - name: Regenerate Python types (ensure up-to-date)
+      shell: bash
+      run: uv run poe codegen-fix
+      working-directory: sdks/python
+
+    - name: Check Python formatting
+      shell: bash
+      run: uv run poe fmt-check
+      working-directory: sdks/python
+
+    - name: Run Python linting
+      shell: bash
+      run: uv run poe lint-check
+      working-directory: sdks/python
+
+    # TODO: Re-enable type checking once type issues are resolved
+    # - name: Run Python type checking
+    #   shell: bash
+    #   run: uv run poe type-check
+    #   working-directory: sdks/python
+
+    - name: Check Python dependencies
+      shell: bash
+      run: uv run poe dep-check
+      working-directory: sdks/python
+
+    - name: Run Python tests
+      shell: bash
+      run: uv run poe test
+      working-directory: sdks/python

--- a/.github/actions/rust-build/action.yml
+++ b/.github/actions/rust-build/action.yml
@@ -1,0 +1,92 @@
+name: 'Rust Build & Test'
+description: 'Comprehensive compilation, testing, and lint analysis for Rust code'
+
+# =============================================================================
+# RUST BUILD & TEST CHECKS
+# =============================================================================
+# This action performs heavy compilation-based checks:
+# - Full test suite execution (cargo test)
+# - Comprehensive linting analysis (cargo clippy)
+#
+# EXECUTION STRATEGY:
+# - Runs in parallel with rust-style for maximum CI efficiency
+# - Shares compilation cache between test and clippy for performance
+# - Uses continue-on-error to run both checks even if one fails
+# - Takes 3-5 minutes but provides comprehensive functionality coverage
+#
+# COMPILATION OPTIMIZATION:
+# - Uses Swatinem/rust-cache for dependency caching
+# - Dependencies are pre-optimized (opt-level = 3) for faster builds
+# - Clippy reuses test compilation artifacts when possible
+#
+# CI INTEGRATION:  
+# - Called from ci.yml as a parallel job alongside rust-style
+# - Supports matrix builds for cross-platform testing
+# - Provides comprehensive coverage while rust-style gives fast feedback
+# =============================================================================
+
+inputs:
+  os:
+    description: 'Operating system to run on'
+    required: false
+    default: 'ubuntu-latest'
+  rust-toolchain:
+    description: 'Rust toolchain version'
+    required: false
+    default: 'stable'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ inputs.rust-toolchain }}
+        components: 'clippy'
+
+    # Configure Rust dependency caching for faster builds
+    - name: Configure Rust cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          stepflow-rs
+
+    # Run the full test suite - continue even if it fails so we can run clippy too
+    - name: Run Rust tests
+      shell: bash
+      run: cargo test
+      working-directory: stepflow-rs
+      continue-on-error: true
+      id: test
+
+    # Run clippy linting - reuses compilation from tests when possible
+    - name: Run Rust linting (clippy)
+      shell: bash
+      run: cargo clippy
+      working-directory: stepflow-rs
+      continue-on-error: true
+      id: clippy
+
+    # Aggregate all results - fail the action if any check failed
+    # This ensures we get complete feedback while still failing CI appropriately
+    - name: Report build & test results
+      shell: bash
+      if: always()
+      run: |
+        echo "=== Rust Build & Test Results ==="
+        
+        # Check each step outcome
+        test_result="${{ steps.test.outcome }}"
+        clippy_result="${{ steps.clippy.outcome }}"
+        
+        echo "🧪 Tests: $test_result"
+        echo "📎 Clippy linting: $clippy_result"
+        
+        # Fail if any check failed
+        if [[ "$test_result" == "failure" || "$clippy_result" == "failure" ]]; then
+          echo "::error::One or more build/test checks failed"
+          echo "::notice::All checks were run to provide complete feedback"
+          exit 1
+        else
+          echo "✅ All build and test checks passed!"
+        fi

--- a/.github/actions/rust-style/action.yml
+++ b/.github/actions/rust-style/action.yml
@@ -1,0 +1,103 @@
+name: 'Rust Style & Quality Checks'
+description: 'Fast parallel checks for Rust code style and dependency hygiene'
+
+# =============================================================================
+# RUST STYLE & QUALITY CHECKS
+# =============================================================================
+# This action performs lightweight checks that don't require compilation:
+# - Code formatting (cargo fmt --check)
+# - Dependency security audit (cargo deny)  
+# - Unused dependency detection (cargo machete)
+#
+# EXECUTION STRATEGY:
+# - Runs in parallel with rust-build for maximum CI efficiency
+# - Provides fast feedback (~30-60s) on common style issues
+# - Uses continue-on-error to ensure all checks run even if earlier ones fail
+# - Aggregates results at the end to provide complete feedback
+#
+# CI INTEGRATION:
+# - Called from ci.yml as a parallel job alongside rust-build
+# - No compilation required, so much faster than test/clippy
+# - Helps developers get quick feedback on style before heavier checks complete
+# =============================================================================
+
+inputs:
+  rust-toolchain:
+    description: 'Rust toolchain version'
+    required: false
+    default: 'stable'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Rust toolchain (minimal)
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: ${{ inputs.rust-toolchain }}
+        components: 'rustfmt'
+
+    # Run formatting check - continue even if it fails so we can run all checks
+    - name: Check Rust formatting
+      shell: bash
+      run: cargo fmt --check
+      working-directory: stepflow-rs
+      continue-on-error: true
+      id: fmt
+
+    # Install and run cargo-deny for dependency security audit
+    - name: Install cargo-deny
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-deny
+
+    - name: Run dependency security audit
+      shell: bash
+      run: cargo deny check
+      working-directory: stepflow-rs
+      continue-on-error: true
+      id: deny
+
+    # Install and run cargo-machete for unused dependency detection
+    - name: Install cargo-machete
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-machete
+
+    - name: Check for unused dependencies
+      shell: bash
+      working-directory: stepflow-rs
+      run: |
+        cargo machete --with-metadata
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+          echo "::error::Unused deps found. Run \`cargo machete --fix --with-metadata\` to fix."
+          exit $exit_code
+        fi
+      continue-on-error: true
+      id: machete
+
+    # Aggregate all results - fail the action if any check failed
+    # This ensures we get complete feedback while still failing CI appropriately
+    - name: Report style check results
+      shell: bash
+      if: always()
+      run: |
+        echo "=== Rust Style & Quality Check Results ==="
+        
+        # Check each step outcome
+        fmt_result="${{ steps.fmt.outcome }}"
+        deny_result="${{ steps.deny.outcome }}"
+        machete_result="${{ steps.machete.outcome }}"
+        
+        echo "📝 Formatting: $fmt_result"
+        echo "🔒 Security audit: $deny_result"  
+        echo "🧹 Unused deps: $machete_result"
+        
+        # Fail if any check failed
+        if [[ "$fmt_result" == "failure" || "$deny_result" == "failure" || "$machete_result" == "failure" ]]; then
+          echo "::error::One or more style/quality checks failed"
+          echo "::notice::All checks were run to provide complete feedback"
+          exit 1
+        else
+          echo "✅ All style and quality checks passed!"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,105 +14,111 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
-# TODO: Split into per-language custom actions and use https://github.com/dorny/paths-filter
-# to run actions only for affected packages.
+# =============================================================================
+# CI OPTIMIZATION STRATEGY
+# =============================================================================
+# This workflow uses path-based filtering to run checks only on changed sub-packages.
+# This significantly reduces CI time by avoiding unnecessary work.
+#
+# APPROACH:
+# 1. Use dorny/paths-filter to detect which sub-packages have changes
+# 2. Use composite actions (.github/actions/*) to encapsulate package-specific logic
+# 3. Run checks conditionally based on detected changes
+# 4. Use a final aggregation job to ensure all required checks pass
+#
+# SUB-PACKAGES:
+# - rust: stepflow-rs Rust workspace (crates/*)
+# - python: sdks/python Python SDK
+# - docs: docs/ Docusaurus documentation site
+#
+# EXTENDING THIS PATTERN:
+# To add new sub-packages (e.g., TypeScript SDK, UI):
+# 1. Create a new composite action in .github/actions/
+# 2. Add path filters below in the 'changes' job
+# 3. Add a conditional job that uses the new composite action
+# 4. Update the 'check-success' job dependencies
+# =============================================================================
+
 jobs:
-  test:
+  # Detect which parts of the codebase have changed
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      python: ${{ steps.filter.outputs.python }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'stepflow-rs/**'
+              - 'schemas/**'
+            python:
+              - 'sdks/python/**'
+              - 'schemas/**'
+            docs:
+              - 'docs/**'
+              - 'README.md'
+              - '*.md'
+
+  # Rust style checks (fast parallel execution)
+  rust-style:
+    name: Rust Style & Quality
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rust-style
+
+  # Rust build & test (heavy compilation)
+  rust-build:
+    name: Rust Build & Test
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     strategy:
       fail-fast: true
       matrix:
         include:
           - { os: ubuntu-latest }
+          # Additional OS can be added when needed:
           # - { os: macos-latest }
-          # - { os: macos-13 }
           # - { os: windows-latest }
-
-    name: Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rust-build
         with:
-          toolchain: stable
-          components: 'clippy'
+          os: ${{ matrix.os }}
 
-      - name: cargo cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            stepflow-rs
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "0.7.5"
-          enable-cache: true
-
-      - name: Set up Python
-        run: uv python install
-        working-directory: sdks/python
-
-      - name: Check Python generated types are up-to-date
-        run: uv run python generate.py --check
-        working-directory: sdks/python
-
-      - name: Run pytests
-        run: uv run pytest tests
-        working-directory: sdks/python
-
-      - name: Run cargo-test
-        run: cargo test
-        working-directory: stepflow-rs
-
-      - name: Lint (clippy)
-        run: cargo clippy
-        working-directory: stepflow-rs
-
-  rustfmt:
-    name: Rust Format
+  # Python SDK checks
+  python-checks:
+    name: Python SDK Checks
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
-        components: 'rustfmt'
-    - name: Format
-      run: cargo fmt --check
-      working-directory: stepflow-rs
-
-  rust-unused-dependencies:
-    name: Rust Unused Dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install cargo-machete
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-machete
-      - name: Run cargo-machete
-        working-directory: stepflow-rs
-        run: |
-          cargo machete --with-metadata
-          exit_code=$?
-          if [ $exit_code -ne 0 ]; then
-            echo "::error::Unused deps check failed. Run \`cargo machete --fix --with-metadata\` to fix."
-            exit $exit_code
-          fi
-
-  rust-cargo-deny:
-    name: Rust Cargo Deny
-    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          manifest-path: stepflow-rs/Cargo.toml
+      - uses: ./.github/actions/python-checks
 
+  # Documentation build validation
+  docs-checks:
+    name: Documentation Checks
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/docs-checks
+
+  # License header validation (runs on all changes)
   licensure:
-    name: Licensure
-    runs-on: ubuntu-22.04
+    name: License Headers
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -120,7 +126,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: licensure
-      - name: Run licensure
+      - name: Check license headers
         run: |
           licensure -c -p
           exit_code=$?
@@ -128,3 +134,95 @@ jobs:
             echo "::error::License check failed. Run \`licensure -p --in-place\` to fix."
             exit $exit_code
           fi
+
+  # Integration tests (runs workflow execution tests with external dependencies)
+  integration-checks:
+    name: Integration Tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Configure Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            stepflow-rs
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.7.5"
+          enable-cache: true
+      - name: Set up Python
+        shell: bash
+        run: uv python install
+        working-directory: sdks/python
+      - name: Run integration tests
+        shell: bash
+        run: ./scripts/test-integration.sh
+
+  # Final aggregation job - ensures all required checks pass
+  # This job is required by branch protection rules
+  check-success:
+    name: All Checks Passed
+    runs-on: ubuntu-latest
+    needs: [changes, rust-style, rust-build, python-checks, docs-checks, licensure, integration-checks]
+    # Always run this job, but fail if any required checks failed
+    if: always()
+    steps:
+      - name: Check all required jobs succeeded
+        run: |
+          # Check if any required job failed or was cancelled
+          if [[ "${{ needs.rust-style.result }}" == "failure" || "${{ needs.rust-style.result }}" == "cancelled" ]]; then
+            echo "::error::Rust style checks failed"
+            exit 1
+          fi
+          if [[ "${{ needs.rust-build.result }}" == "failure" || "${{ needs.rust-build.result }}" == "cancelled" ]]; then
+            echo "::error::Rust build checks failed"
+            exit 1
+          fi
+          if [[ "${{ needs.python-checks.result }}" == "failure" || "${{ needs.python-checks.result }}" == "cancelled" ]]; then
+            echo "::error::Python checks failed"
+            exit 1
+          fi
+          if [[ "${{ needs.docs-checks.result }}" == "failure" || "${{ needs.docs-checks.result }}" == "cancelled" ]]; then
+            echo "::error::Documentation checks failed"
+            exit 1
+          fi
+          if [[ "${{ needs.licensure.result }}" == "failure" || "${{ needs.licensure.result }}" == "cancelled" ]]; then
+            echo "::error::License checks failed"
+            exit 1
+          fi
+          if [[ "${{ needs.integration-checks.result }}" == "failure" || "${{ needs.integration-checks.result }}" == "cancelled" ]]; then
+            echo "::error::Integration checks failed"
+            exit 1
+          fi
+          
+          # Check if required jobs were skipped when they should have run
+          if [[ "${{ needs.changes.outputs.rust }}" == "true" && "${{ needs.rust-style.result }}" == "skipped" ]]; then
+            echo "::error::Rust changes detected but rust-style was skipped"
+            exit 1
+          fi
+          if [[ "${{ needs.changes.outputs.rust }}" == "true" && "${{ needs.rust-build.result }}" == "skipped" ]]; then
+            echo "::error::Rust changes detected but rust-build was skipped"
+            exit 1
+          fi
+          if [[ "${{ needs.changes.outputs.python }}" == "true" && "${{ needs.python-checks.result }}" == "skipped" ]]; then
+            echo "::error::Python changes detected but python-checks was skipped"
+            exit 1
+          fi
+          if [[ "${{ needs.changes.outputs.docs }}" == "true" && "${{ needs.docs-checks.result }}" == "skipped" ]]; then
+            echo "::error::Documentation changes detected but docs-checks was skipped"
+            exit 1
+          fi
+          if [[ ("${{ needs.changes.outputs.rust }}" == "true" || "${{ needs.changes.outputs.python }}" == "true") && "${{ needs.integration-checks.result }}" == "skipped" ]]; then
+            echo "::error::Rust or Python changes detected but integration-checks was skipped"
+            exit 1
+          fi
+          
+          echo "✅ All required checks passed!"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ cargo build --release
 
 ### Running Tests
 ```bash
-# Run all tests (run from stepflow-rs directory)
+# Fast unit tests only (no external dependencies required)
 cd stepflow-rs
 cargo test
 
@@ -28,6 +28,12 @@ cargo test -p stepflow-execution
 
 # Run a specific test
 cargo test -p stepflow-execution -- execute_flows
+
+# Integration tests (requires Python environment and stepflow binary)
+./scripts/test-integration.sh
+
+# Complete test suite (unit tests + Python SDK tests + integration tests)
+./scripts/test-all.sh
 ```
 
 ### Running the App

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ cargo build --release
 ### Running Tests
 
 ```bash
-# Run all tests (run from stepflow-rs directory)
+# Run fast unit tests (no external dependencies)
 cd stepflow-rs
 cargo test
 
@@ -71,6 +71,13 @@ cargo test -p stepflow-execution
 
 # Run a specific test
 cargo test -p stepflow-execution -- execute_flows
+
+# Run integration tests (requires Python environment)
+cd ..
+./scripts/test-integration.sh
+
+# Run complete test suite (unit + Python SDK + integration)
+./scripts/test-all.sh
 ```
 
 ### Code Quality

--- a/examples/file-loading/test-load.yaml
+++ b/examples/file-loading/test-load.yaml
@@ -9,7 +9,10 @@ steps:
 
 output:
   loaded_data: { $from: { step: "load_sales_data" }, path: "data" }
-  file_metadata: { $from: { step: "load_sales_data" }, path: "metadata" }
+  file_metadata:
+    size_bytes: { $from: { step: "load_sales_data" }, path: "$.metadata.size_bytes" }
+    format: { $from: { step: "load_sales_data" }, path: "$.metadata.format" }
+
 
 test:
   cases:
@@ -23,6 +26,5 @@ test:
           test: "data"
           value: 42
         file_metadata:
-          resolved_path: "../../../examples/file-loading/test-data.json"
           size_bytes: 29
           format: "json"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
 # See the NOTICE file distributed with this work for additional information regarding copyright
 # ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -14,19 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
-# See the NOTICE file distributed with this work for additional information regarding copyright
-# ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the License.  You may obtain a
-# copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied.  See the License for the specific language governing permissions and limitations under
-# the License.
-
 set -e
 
 echo "🚀 Running complete test suite..."

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the License.  You may obtain a
+# copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+set -e
+
+echo "🚀 Running complete test suite..."
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+# Run Rust unit tests
+echo "📦 Running Rust unit tests..."
+cd stepflow-rs
+cargo test
+cd ..
+
+# Run Python SDK tests
+echo "🐍 Running Python SDK tests..."
+cd sdks/python
+uv run poe test
+cd ../..
+
+# Run integration tests
+echo "🔗 Running integration tests..."
+./scripts/test-integration.sh
+
+echo "✅ Complete test suite finished successfully"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
 # See the NOTICE file distributed with this work for additional information regarding copyright
 # ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding copyright
+# ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the License.  You may obtain a
+# copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+set -e
+
+echo "🧪 Running integration tests..."
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+# Setup Python environment
+echo "🐍 Setting up Python environment..."
+cd sdks/python
+uv sync
+cd ../..
+
+# Build stepflow binary
+echo "🔨 Building stepflow binary..."
+cd stepflow-rs
+cargo build
+
+# Test workflows using stepflow test command
+echo "🔗 Testing workflows..."
+
+# Test the main test workflows (equivalent to test_run_test_workflows)
+echo "  Testing stepflow-rs/tests directory..."
+./target/debug/stepflow test ../../tests --config ../../tests/stepflow-config.yml
+
+# Test the examples (equivalent to test_run_example_workflows)  
+echo "  Testing examples directory..."
+./target/debug/stepflow test ../../../examples --config ../../../examples/basic/stepflow-config.yml
+
+echo "✅ Integration tests completed successfully"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -14,19 +14,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
-# See the NOTICE file distributed with this work for additional information regarding copyright
-# ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance with the License.  You may obtain a
-# copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the License
-# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-# or implied.  See the License for the specific language governing permissions and limitations under
-# the License.
-
 set -e
 
 echo "🧪 Running integration tests..."
@@ -53,10 +40,10 @@ echo "🔗 Testing workflows..."
 
 # Test the main test workflows (equivalent to test_run_test_workflows)
 echo "  Testing stepflow-rs/tests directory..."
-./target/debug/stepflow test ../../tests --config ../../tests/stepflow-config.yml
+./target/debug/stepflow test ../stepflow-rs/tests
 
-# Test the examples (equivalent to test_run_example_workflows)  
+# Test the examples (equivalent to test_run_example_workflows)
 echo "  Testing examples directory..."
-./target/debug/stepflow test ../../../examples --config ../../../examples/basic/stepflow-config.yml
+./target/debug/stepflow test ../examples
 
 echo "✅ Integration tests completed successfully"

--- a/sdks/python/generate.py
+++ b/sdks/python/generate.py
@@ -14,8 +14,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-"""
-Type generation script for StepFlow Python SDK.
+"""Type generation script for StepFlow Python SDK.
 
 This script generates the protocol and flow types from the JSON schemas.
 """
@@ -29,7 +28,6 @@ from pathlib import Path
 
 def _generate_types_content(schema_name: str, verbose: bool = True) -> str:
     """Generate types from a schema file and return the processed content."""
-
     # Get paths
     script_dir = Path(__file__).parent
     project_root = script_dir.parent.parent
@@ -45,7 +43,7 @@ def _generate_types_content(schema_name: str, verbose: bool = True) -> str:
     # Generate to temporary file
     with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as temp_file:
         temp_path = Path(temp_file.name)
-        
+
         # Run datamodel-code-generator
         cmd = [
             "python",
@@ -77,13 +75,13 @@ def _generate_types_content(schema_name: str, verbose: bool = True) -> str:
             raise RuntimeError(f"Error generating {schema_name}: {result.stderr}")
 
         if verbose:
-            print(f"✓ Generated to temporary file")
+            print("✓ Generated to temporary file")
 
         # Process the generated file to add license header and remove timestamp
         if verbose:
             print(f"Processing generated {schema_name} file...")
 
-        with open(temp_path, "r") as f:
+        with open(temp_path) as f:
             content = f.read()
 
         # Parse the content
@@ -154,7 +152,6 @@ def generate_types_from_schema(
     schema_name: str, output_filename: str, check_only: bool = False
 ) -> int:
     """Generate types from a schema file."""
-
     # Get paths
     script_dir = Path(__file__).parent
     output_path = script_dir / "src" / "stepflow_sdk" / output_filename
@@ -166,7 +163,7 @@ def generate_types_from_schema(
         if check_only:
             # Compare with existing file
             if output_path.exists():
-                with open(output_path, "r") as f:
+                with open(output_path) as f:
                     existing_content = f.read()
 
                 if existing_content != new_content:
@@ -191,7 +188,6 @@ def generate_types_from_schema(
 
 def main():
     """Generate protocol and flow types from JSON schemas."""
-
     parser = argparse.ArgumentParser(
         description="Generate StepFlow Python SDK types from JSON schemas"
     )

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -16,6 +16,10 @@ dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=4.1.0",
+    "poethepoet>=0.24.0",
+    "ruff>=0.9.4",
+    "mypy>=1.8.0",
+    "deptry>=0.22.0",
 ]
 
 [project.scripts]
@@ -24,3 +28,118 @@ stepflow_sdk = "stepflow_sdk.main:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.poe]
+# comment this out to debug poe tasks
+verbosity = -1
+
+[tool.poe.env]
+RUFF = "ruff@0.9.4"
+DEPTRY = "deptry@0.22.0"
+
+[tool.poe.tasks.fmt-check]
+help = "Runs `ruff format --check` to check for formatting issues (fix with `fmt-fix`)"
+cmd = "uvx ${RUFF} format --check ."
+
+[tool.poe.tasks.fmt-fix]
+help = "Runs `ruff format` to fix formatting issues"
+cmd = "uvx ${RUFF} format ."
+
+[tool.poe.tasks.lint-check]
+help = "Runs `ruff check` to check for lint issues (fix with `lint-fix`)"
+cmd = "uvx ${RUFF} check ."
+
+[tool.poe.tasks.lint-fix]
+help = "Runs `ruff check --fix` to fix lint issues"
+cmd = "uvx ${RUFF} check --fix ."
+
+[tool.poe.tasks.type-check]
+help = "Runs `mypy` to check for static type issues"
+cmd = "uv run mypy src tests"
+
+[tool.poe.tasks.dep-check]
+help = "Runs `deptry` to check for dependency issues"
+cmd = "uvx ${DEPTRY} src tests"
+
+[tool.poe.tasks.codegen-check]
+help = "Check that generated types are up-to-date"
+cmd = "uv run python generate.py --check"
+
+[tool.poe.tasks.codegen-fix]
+help = "Regenerate types from schemas"
+sequence = [
+    {cmd = "uv run python generate.py"},
+    {cmd = "uvx ${RUFF} format src/stepflow_sdk/generated_*.py"},
+    {cmd = "uvx ${RUFF} check --fix src/stepflow_sdk/generated_*.py"}
+]
+
+[tool.poe.tasks.test]
+help = "Run tests"
+cmd = "uv run pytest tests"
+
+# Aliases for common commands
+[tool.poe.tasks.fmt]
+help = "Alias for fmt-fix"
+ref = "fmt-fix"
+
+[tool.poe.tasks.lint]
+help = "Runs all checks (fixing where possible)"
+sequence = ["codegen-fix", "fmt-fix", "lint-fix", "dep-check"]
+
+[tool.poe.tasks.typecheck]
+help = "Alias for type-check"
+ref = "type-check"
+
+[tool.poe.tasks.check]
+help = "Runs all checks and tests"
+sequence = ["lint", "test"]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP", "B", "C4"]
+ignore = [
+    "E501",  # Line too long (we'll gradually fix these)
+    "E402",  # Module level import not at top of file
+    "E722",  # Bare except (specific cases need manual review)
+    "UP007", # Union type syntax (compatibility consideration)
+    "UP038", # isinstance with tuple (readability preference)
+    "B904",  # Exception chaining (needs context-specific review)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"**/{tests,tools,scripts}/*" = ["D", "DOC", "T201", "B018", "F841", "E712"]
+"generate.py" = ["T201", "E501"]  # Allow prints and long lines in build script
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+
+[tool.mypy]
+python_version = "3.13"
+warn_return_any = true
+warn_unused_configs = true
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+
+# Disable some strict checks for now - can be enabled gradually
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_decorators = false
+no_implicit_optional = false
+strict_equality = false
+
+# Ignore errors in tests and generated files
+[[tool.mypy.overrides]]
+module = "tests.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "stepflow_sdk.generated_*"
+ignore_errors = true

--- a/sdks/python/src/stepflow_sdk/__init__.py
+++ b/sdks/python/src/stepflow_sdk/__init__.py
@@ -13,44 +13,38 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from .server import StepflowStdioServer
 from .context import StepflowContext
 from .flow_builder import FlowBuilder, StepHandle
-from .value import (
-    Value,
-    Valuable,
-    JsonPath,
-    StepReference, 
-    WorkflowInput
-)
 from .generated_flow import (
     ErrorAction,
-    OnErrorFail,
-    OnErrorSkip,
-    OnErrorRetry,
     OnErrorDefault,
-    SkipAction,
-    OnSkipSkip,
+    OnErrorFail,
+    OnErrorRetry,
+    OnErrorSkip,
     OnSkipDefault,
+    OnSkipSkip,
+    SkipAction,
 )
+from .server import StepflowStdioServer
+from .value import JsonPath, StepReference, Valuable, Value, WorkflowInput
 
 __all__ = [
     # Core classes
-    "StepflowStdioServer", 
-    "StepflowContext", 
+    "StepflowStdioServer",
+    "StepflowContext",
     "FlowBuilder",
     # Value API for cleaner workflow definitions
     "Value",
     "Valuable",
     # Helper classes for type hints and intermediate objects
     "JsonPath",
-    "StepHandle", 
-    "StepReference", 
+    "StepHandle",
+    "StepReference",
     "WorkflowInput",
     # Error and Skip Action types
     "ErrorAction",
     "OnErrorFail",
-    "OnErrorSkip", 
+    "OnErrorSkip",
     "OnErrorRetry",
     "OnErrorDefault",
     "SkipAction",
@@ -60,4 +54,5 @@ __all__ = [
 
 if __name__ == "__main__":
     from . import main
+
     main.main()

--- a/sdks/python/src/stepflow_sdk/context.py
+++ b/sdks/python/src/stepflow_sdk/context.py
@@ -18,28 +18,33 @@ from __future__ import annotations
 """
 Context API for stepflow components to interact with the runtime.
 """
-import json
-import sys
 import asyncio
-from typing import Any, Dict
+import sys
+from typing import Any
 from uuid import uuid4
-import msgspec
-from stepflow_sdk.generated_protocol import RequestId, Method, GetBlobResult, PutBlobResult
+
+from stepflow_sdk.generated_protocol import (
+    GetBlobResult,
+    PutBlobResult,
+)
 from stepflow_sdk.message_decoder import MessageDecoder
 
 
 class StepflowContext:
-    """
-    Context for stepflow components to make calls back to the runtime.
-    
-    This allows components to store/retrieve blobs and perform other 
+    """Context for stepflow components to make calls back to the runtime.
+
+    This allows components to store/retrieve blobs and perform other
     runtime operations through bidirectional communication.
     """
-    
-    def __init__(self, outgoing_queue: asyncio.Queue, message_decoder: MessageDecoder[asyncio.Future]):
+
+    def __init__(
+        self,
+        outgoing_queue: asyncio.Queue,
+        message_decoder: MessageDecoder[asyncio.Future],
+    ):
         self._outgoing_queue = outgoing_queue
         self._message_decoder = message_decoder
-        
+
     async def _send_request(self, method: str, params: Any, result_type: type) -> Any:
         """Send a request to the stepflow runtime and wait for response."""
         request_id = str(uuid4())
@@ -47,92 +52,83 @@ class StepflowContext:
             "jsonrpc": "2.0",
             "id": request_id,
             "method": method,
-            "params": params
+            "params": params,
         }
-        
+
         # Create future for response
         future = asyncio.Future()
-        
+
         # Register the pending request with the message decoder
         self._message_decoder.register_request(request_id, result_type, future)
-        
+
         # Send request via queue
         await self._outgoing_queue.put(request)
-        
+
         # Wait for response - the MessageDecoder will resolve this future
         # when the response is received
         response_message = await future
-        
+
         # Extract the result from the response message
-        if hasattr(response_message, 'result'):
+        if hasattr(response_message, "result"):
             return response_message.result
         else:
             # Handle error case
             raise Exception(f"Request failed: {response_message.error}")
-        
-    
-    
+
     async def put_blob(self, data: Any) -> str:
-        """
-        Store JSON data as a blob and return its content-based ID.
-        
+        """Store JSON data as a blob and return its content-based ID.
+
         Args:
             data: The JSON-serializable data to store
-            
+
         Returns:
             The blob ID (SHA-256 hash) for the stored data
         """
         params = {"data": data}
         response = await self._send_request("blobs/put", params, PutBlobResult)
         return response.blob_id
-    
+
     async def get_blob(self, blob_id: str) -> Any:
-        """
-        Retrieve JSON data by blob ID.
-        
+        """Retrieve JSON data by blob ID.
+
         Args:
             blob_id: The blob ID to retrieve
-            
+
         Returns:
             The JSON data associated with the blob ID
         """
         params = {"blob_id": blob_id}
         response = await self._send_request("blobs/get", params, GetBlobResult)
         return response.data
-    
+
     def get_sync_proxy(self):
-        """
-        Get a synchronous proxy object for use in non-async contexts.
+        """Get a synchronous proxy object for use in non-async contexts.
         This uses the current event loop to run async operations.
         """
         return SyncBlobProxy(self)
-    
+
     def log(self, message):
-        """
-        Log a message.
-        """
+        """Log a message."""
         print(f"PYTHON: {message}", file=sys.stderr)
 
 
 class SyncBlobProxy:
-    """
-    Synchronous proxy for blob operations that can be used in custom component code.
-    """
-    
+    """Synchronous proxy for blob operations that can be used in custom component code."""
+
     def __init__(self, context: StepflowContext):
         self._context = context
-        
+
     def put_blob(self, data: Any) -> str:
-        """
-        Store JSON data as a blob synchronously.
-        
+        """Store JSON data as a blob synchronously.
+
         Args:
             data: The JSON-serializable data to store
-            
+
         Returns:
             The blob ID (SHA-256 hash) for the stored data
         """
         import asyncio
+
         # Get the current event loop
         loop = asyncio.get_event_loop()
         if loop.is_running():
@@ -140,28 +136,30 @@ class SyncBlobProxy:
             # This is a bit of a hack, but we need to run the task to completion
             # In a real implementation, this would need to be handled differently
             import concurrent.futures
+
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 future = executor.submit(asyncio.run, self._context.put_blob(data))
                 return future.result()
         else:
             return asyncio.run(self._context.put_blob(data))
-    
+
     def get_blob(self, blob_id: str) -> Any:
-        """
-        Retrieve JSON data by blob ID synchronously.
-        
+        """Retrieve JSON data by blob ID synchronously.
+
         Args:
             blob_id: The blob ID to retrieve
-            
+
         Returns:
             The JSON data associated with the blob ID
         """
         import asyncio
+
         # Get the current event loop
         loop = asyncio.get_event_loop()
         if loop.is_running():
             # If we're already in an async context, create a task
             import concurrent.futures
+
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 future = executor.submit(asyncio.run, self._context.get_blob(blob_id))
                 return future.result()

--- a/sdks/python/src/stepflow_sdk/main.py
+++ b/sdks/python/src/stepflow_sdk/main.py
@@ -22,9 +22,11 @@ server = StepflowStdioServer()
 # Register the UDF component
 server.component(udf)
 
+
 def main():
     # Start the server
     server.run()
+
 
 if __name__ == "__main__":
     main()

--- a/sdks/python/src/stepflow_sdk/udf.py
+++ b/sdks/python/src/stepflow_sdk/udf.py
@@ -13,10 +13,12 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-import sys
-import msgspec
 import inspect
+import sys
 from typing import Any
+
+import msgspec
+
 from stepflow_sdk.context import StepflowContext
 
 # Global cache for compiled functions by blob_id
@@ -29,8 +31,7 @@ class UdfInput(msgspec.Struct):
 
 
 async def udf(input: UdfInput, context: StepflowContext) -> Any:
-    """
-    Execute user-defined function (UDF) using cached compiled functions from blobs.
+    """Execute user-defined function (UDF) using cached compiled functions from blobs.
 
     Args:
         input: Contains blob_id (referencing stored code/schema) and input (data)
@@ -93,10 +94,9 @@ async def udf(input: UdfInput, context: StepflowContext) -> Any:
 def _compile_function(
     code: str, function_name: str | None, input_schema: dict, context: StepflowContext
 ):
-    """
-    Compile a function from code string and return the callable with validation.
-    """
+    """Compile a function from code string and return the callable with validation."""
     import json
+
     import jsonschema
 
     # Create a safe execution environment

--- a/sdks/python/tests/test_flow_builder.py
+++ b/sdks/python/tests/test_flow_builder.py
@@ -13,18 +13,19 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+
 import pytest
-import json
-from stepflow_sdk.flow_builder import FlowBuilder
+
 from stepflow_sdk import (
-    OnErrorFail,
-    OnErrorSkip, 
-    OnErrorRetry,
     OnErrorDefault,
-    Value,
+    OnErrorFail,
+    OnErrorRetry,
+    OnErrorSkip,
     StepReference,
+    Value,
     WorkflowInput,
 )
+from stepflow_sdk.flow_builder import FlowBuilder
 
 
 def test_basic_flow_builder():
@@ -96,7 +97,7 @@ def test_step_references():
 
     # Set output to make the test complete
     builder.set_output({"result": ref1})
-    
+
     flow = builder.build()
     assert len(flow.steps) == 5
 
@@ -127,7 +128,7 @@ def test_workflow_input_references():
 
     # Set output to make the test complete
     builder.set_output({"result": input_ref})
-    
+
     flow = builder.build()
     assert len(flow.steps) == 4
 
@@ -150,7 +151,7 @@ def test_literal_values():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     assert len(flow.steps) == 1
 
@@ -181,7 +182,7 @@ def test_error_handling():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     assert len(flow.steps) == 3
 
@@ -213,7 +214,7 @@ def test_error_default_handling():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     assert len(flow.steps) == 1
 
@@ -227,18 +228,16 @@ def test_error_default_handling():
 def test_build_requires_output():
     """Test that build() fails when output hasn't been set."""
     builder = FlowBuilder()
-    
+
     # Add a step but don't set output
     builder.add_step(
-        id="test_step",
-        component="test/component",
-        input_data={"value": 1}
+        id="test_step", component="test/component", input_data={"value": 1}
     )
-    
+
     # build() should fail without output
     with pytest.raises(ValueError, match="Flow output must be set before building"):
         builder.build()
-    
+
     # After setting output, build() should succeed
     builder.set_output({"result": "success"})
     flow = builder.build()
@@ -262,7 +261,7 @@ def test_step_ids():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
 
     # Check that IDs were set correctly
@@ -300,7 +299,7 @@ def test_complex_nested_references():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     assert len(flow.steps) == 2
 
@@ -362,7 +361,7 @@ def test_get_step_references():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     references = builder.step("test_step").get_references()
 
@@ -389,7 +388,7 @@ def test_get_references_with_skip_condition():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     references = builder.step("skip_test").get_references()
 
@@ -416,7 +415,7 @@ def test_get_references_with_literal_values():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     references = builder.step("literal_test").get_references()
 
@@ -442,7 +441,7 @@ def test_get_references_mixed_types():
 
     # Set output to make the test complete
     builder.set_output({"result": "done"})
-    
+
     flow = builder.build()
     references = builder.step("mixed_test").get_references()
 
@@ -515,7 +514,7 @@ def test_flowbuilder_load_and_extend():
 
     # Set output to make the test complete
     original_builder.set_output({"result": "done"})
-    
+
     original_flow = original_builder.build()
 
     # Load the flow

--- a/sdks/python/tests/test_json_encoding.py
+++ b/sdks/python/tests/test_json_encoding.py
@@ -14,20 +14,20 @@
 # the License.
 
 import json
-import pytest
 from uuid import UUID
 
 import msgspec
+
 from stepflow_sdk.generated_protocol import (
-    MethodRequest,
-    MethodSuccess,
-    MethodError,
-    Notification,
-    Method,
+    Error,
+    Initialized,
     InitializeParams,
     InitializeResult,
-    Initialized,
-    Error,
+    Method,
+    MethodError,
+    MethodRequest,
+    MethodSuccess,
+    Notification,
 )
 
 
@@ -36,13 +36,13 @@ def test_method_request_default_jsonrpc():
     request = MethodRequest(
         id="test-123",
         method=Method.initialize,
-        params=InitializeParams(runtime_protocol_version=1, protocol_prefix="python")
+        params=InitializeParams(runtime_protocol_version=1, protocol_prefix="python"),
     )
-    
+
     # Encode to JSON
     json_bytes = msgspec.json.encode(request)
     json_dict = json.loads(json_bytes)
-    
+
     # Verify jsonrpc field is present and correct
     assert "jsonrpc" in json_dict
     assert json_dict["jsonrpc"] == "2.0"
@@ -53,14 +53,13 @@ def test_method_request_default_jsonrpc():
 def test_method_success_default_jsonrpc():
     """Test that MethodSuccess includes jsonrpc='2.0' in JSON even when not explicitly set."""
     response = MethodSuccess(
-        id=UUID(int=42),
-        result=InitializeResult(server_protocol_version=1)
+        id=UUID(int=42), result=InitializeResult(server_protocol_version=1)
     )
-    
+
     # Encode to JSON
     json_bytes = msgspec.json.encode(response)
     json_dict = json.loads(json_bytes)
-    
+
     # Verify jsonrpc field is present and correct
     assert "jsonrpc" in json_dict
     assert json_dict["jsonrpc"] == "2.0"
@@ -71,14 +70,13 @@ def test_method_success_default_jsonrpc():
 def test_method_error_default_jsonrpc():
     """Test that MethodError includes jsonrpc='2.0' in JSON even when not explicitly set."""
     error_response = MethodError(
-        id="error-test",
-        error=Error(code=-32601, message="Method not found")
+        id="error-test", error=Error(code=-32601, message="Method not found")
     )
-    
+
     # Encode to JSON
     json_bytes = msgspec.json.encode(error_response)
     json_dict = json.loads(json_bytes)
-    
+
     # Verify jsonrpc field is present and correct
     assert "jsonrpc" in json_dict
     assert json_dict["jsonrpc"] == "2.0"
@@ -89,15 +87,12 @@ def test_method_error_default_jsonrpc():
 
 def test_notification_default_jsonrpc():
     """Test that Notification includes jsonrpc='2.0' in JSON even when not explicitly set."""
-    notification = Notification(
-        method=Method.initialized,
-        params=Initialized()
-    )
-    
+    notification = Notification(method=Method.initialized, params=Initialized())
+
     # Encode to JSON
     json_bytes = msgspec.json.encode(notification)
     json_dict = json.loads(json_bytes)
-    
+
     # Verify jsonrpc field is present and correct
     assert "jsonrpc" in json_dict
     assert json_dict["jsonrpc"] == "2.0"
@@ -111,13 +106,13 @@ def test_explicit_jsonrpc_override():
         id="explicit-test",
         method=Method.initialize,
         params=InitializeParams(runtime_protocol_version=1, protocol_prefix="python"),
-        jsonrpc="2.0"  # Explicitly set
+        jsonrpc="2.0",  # Explicitly set
     )
-    
+
     # Encode to JSON
     json_bytes = msgspec.json.encode(request)
     json_dict = json.loads(json_bytes)
-    
+
     # Verify jsonrpc field is present and correct
     assert "jsonrpc" in json_dict
     assert json_dict["jsonrpc"] == "2.0"
@@ -128,13 +123,13 @@ def test_round_trip_decoding():
     original_request = MethodRequest(
         id=12345,
         method=Method.components_list,
-        params=InitializeParams(runtime_protocol_version=1, protocol_prefix="test")
+        params=InitializeParams(runtime_protocol_version=1, protocol_prefix="test"),
     )
-    
+
     # Encode to JSON
     json_bytes = msgspec.json.encode(original_request)
     json_dict = json.loads(json_bytes)
-    
+
     # Verify the JSON has correct structure including jsonrpc
     assert json_dict["id"] == 12345
     assert json_dict["method"] == "components/list"
@@ -148,26 +143,19 @@ def test_all_message_types_have_jsonrpc():
         MethodRequest(
             id="req",
             method=Method.initialize,
-            params=InitializeParams(runtime_protocol_version=1, protocol_prefix="test")
+            params=InitializeParams(runtime_protocol_version=1, protocol_prefix="test"),
         ),
-        MethodSuccess(
-            id="success",
-            result=InitializeResult(server_protocol_version=1)
-        ),
-        MethodError(
-            id="error",
-            error=Error(code=-32000, message="Test error")
-        ),
-        Notification(
-            method=Method.initialized,
-            params=Initialized()
-        )
+        MethodSuccess(id="success", result=InitializeResult(server_protocol_version=1)),
+        MethodError(id="error", error=Error(code=-32000, message="Test error")),
+        Notification(method=Method.initialized, params=Initialized()),
     ]
-    
+
     for message in messages:
         json_bytes = msgspec.json.encode(message)
         json_dict = json.loads(json_bytes)
-        
+
         # Every message should have jsonrpc field
         assert "jsonrpc" in json_dict, f"Missing jsonrpc in {type(message).__name__}"
-        assert json_dict["jsonrpc"] == "2.0", f"Wrong jsonrpc value in {type(message).__name__}"
+        assert json_dict["jsonrpc"] == "2.0", (
+            f"Wrong jsonrpc value in {type(message).__name__}"
+        )

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -149,6 +149,28 @@ ruff = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/7e/75a1990a7244a3d3c5364353ac76f1173aa568a67793199d09f995b66c29/deptry-0.23.0.tar.gz", hash = "sha256:4915a3590ccf38ad7a9176aee376745aa9de121f50f8da8fb9ccec87fa93e676", size = 200920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/85/a8b77c8a87e7c9e81ce8437d752879b5281fd8a0b8a114c6d393f980aa72/deptry-0.23.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1f2a6817a37d76e8f6b667381b7caf6ea3e6d6c18b5be24d36c625f387c79852", size = 1756706 },
+    { url = "https://files.pythonhosted.org/packages/53/bf/26c58af1467df6e889c6b969c27dad2c67b8bd625320d9db7d70277a222f/deptry-0.23.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9601b64cc0aed42687fdd5c912d5f1e90d7f7333fb589b14e35bfdfebae866f3", size = 1657001 },
+    { url = "https://files.pythonhosted.org/packages/ae/7d/b0bd6a50ec3f87b0a5ed3bff64ac2bd5bd8d3205e570bc5bc3170f26a01f/deptry-0.23.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6172b2205f6e84bcc9df25226693d4deb9576a6f746c2ace828f6d13401d357", size = 1754607 },
+    { url = "https://files.pythonhosted.org/packages/e6/1b/79b1213bb9b58b0bcc200867cd6d64cd76ec4b9c5cdb76f95c3e6ee7b92e/deptry-0.23.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cfa4b3a46ee8a026eaa38e4b9ba43fe6036a07fe16bf0a663cb611b939f6af8", size = 1831961 },
+    { url = "https://files.pythonhosted.org/packages/09/d6/607004f20637987d437f420f3dad4d6f1a87a4a83380ab60220397ee8fbe/deptry-0.23.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:9d03cc99a61c348df92074a50e0a71b28f264f0edbf686084ca90e6fd44e3abe", size = 1932126 },
+    { url = "https://files.pythonhosted.org/packages/ff/ff/6fff20bf2632727af55dc3a24a6f5634dcdf34fd785402a55207ba49d9cc/deptry-0.23.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:9a46f78098f145100dc582a59af8548b26cdfa16cf0fbd85d2d44645e724cb6a", size = 2004755 },
+    { url = "https://files.pythonhosted.org/packages/41/30/1b6217bdccf2144d4c3e78f89b2a84db82478b2449599c2d3b4b21a89043/deptry-0.23.0-cp39-abi3-win_amd64.whl", hash = "sha256:d53e803b280791d89a051b6183d9dc40411200e22a8ab7e6c32c6b169822a664", size = 1606944 },
+    { url = "https://files.pythonhosted.org/packages/28/ab/47398041d11b19aa9db28f28cf076dbe42aba3e16d67d3e7911330e3a304/deptry-0.23.0-cp39-abi3-win_arm64.whl", hash = "sha256:da7678624f4626d839c8c03675452cefc59d6cf57d25c84a9711dae514719279", size = 1518394 },
+]
+
+[[package]]
 name = "genson"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -326,6 +348,26 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/92c7fa98112e4d9eb075a239caa4ef4649ad7d441545ccffbd5e34607cbb/mypy-1.16.1.tar.gz", hash = "sha256:6bd00a0a2094841c5e47e7374bb42b83d64c527a502e3334e1173a0c24437bab", size = 3324747 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/e3/96964af4a75a949e67df4b95318fe2b7427ac8189bbc3ef28f92a1c5bc56/mypy-1.16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ddc91eb318c8751c69ddb200a5937f1232ee8efb4e64e9f4bc475a33719de438", size = 11063480 },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/cd1a42b8e5be278fab7010fb289d9307a63e07153f0ae1510a3d7b703193/mypy-1.16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:87ff2c13d58bdc4bbe7dc0dedfe622c0f04e2cb2a492269f3b418df2de05c536", size = 10090538 },
+    { url = "https://files.pythonhosted.org/packages/c9/4f/c3c6b4b66374b5f68bab07c8cabd63a049ff69796b844bc759a0ca99bb2a/mypy-1.16.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a7cfb0fe29fe5a9841b7c8ee6dffb52382c45acdf68f032145b75620acfbd6f", size = 11836839 },
+    { url = "https://files.pythonhosted.org/packages/b4/7e/81ca3b074021ad9775e5cb97ebe0089c0f13684b066a750b7dc208438403/mypy-1.16.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:051e1677689c9d9578b9c7f4d206d763f9bbd95723cd1416fad50db49d52f359", size = 12715634 },
+    { url = "https://files.pythonhosted.org/packages/e9/95/bdd40c8be346fa4c70edb4081d727a54d0a05382d84966869738cfa8a497/mypy-1.16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d5d2309511cc56c021b4b4e462907c2b12f669b2dbeb68300110ec27723971be", size = 12895584 },
+    { url = "https://files.pythonhosted.org/packages/5a/fd/d486a0827a1c597b3b48b1bdef47228a6e9ee8102ab8c28f944cb83b65dc/mypy-1.16.1-cp313-cp313-win_amd64.whl", hash = "sha256:4f58ac32771341e38a853c5d0ec0dfe27e18e27da9cdb8bbc882d2249c71a3ee", size = 9573886 },
+    { url = "https://files.pythonhosted.org/packages/cf/d3/53e684e78e07c1a2bf7105715e5edd09ce951fc3f47cf9ed095ec1b7a037/mypy-1.16.1-py3-none-any.whl", hash = "sha256:5fc2ac4027d0ef28d6ba69a0343737a23c4d1b83672bf38d1fe237bdc0643b37", size = 2265923 },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -341,6 +383,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+]
+
+[[package]]
+name = "pastel"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/f1/4594f5e0fcddb6953e5b8fe00da8c317b8b41b547e2b3ae2da7512943c62/pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d", size = 7555 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/18/a8444036c6dd65ba3624c63b734d3ba95ba63ace513078e1580590075d21/pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364", size = 5955 },
 ]
 
 [[package]]
@@ -368,6 +419,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "poethepoet"
+version = "0.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pastel" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/ac/311c8a492dc887f0b7a54d0ec3324cb2f9538b7b78ea06e5f7ae1f167e52/poethepoet-0.36.0.tar.gz", hash = "sha256:2217b49cb4e4c64af0b42ff8c4814b17f02e107d38bc461542517348ede25663", size = 66854 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/29/dedb3a6b7e17ea723143b834a2da428a7d743c80d5cd4d22ed28b5e8c441/poethepoet-0.36.0-py3-none-any.whl", hash = "sha256:693e3c1eae9f6731d3613c3c0c40f747d3c5c68a375beda42e590a63c5623308", size = 88031 },
 ]
 
 [[package]]
@@ -484,6 +548,18 @@ wheels = [
 ]
 
 [[package]]
+name = "requirements-parser"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782 },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -564,9 +640,13 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "datamodel-code-generator", extra = ["http", "ruff"] },
+    { name = "deptry" },
+    { name = "mypy" },
+    { name = "poethepoet" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -578,9 +658,13 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "datamodel-code-generator", extras = ["http", "ruff"], specifier = ">=0.31.2" },
+    { name = "deptry", specifier = ">=0.22.0" },
+    { name = "mypy", specifier = ">=1.8.0" },
+    { name = "poethepoet", specifier = ">=0.24.0" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "ruff", specifier = ">=0.9.4" },
 ]
 
 [[package]]

--- a/stepflow-rs/README.md
+++ b/stepflow-rs/README.md
@@ -1,0 +1,112 @@
+# StepFlow Rust Engine
+
+The core Rust-based execution engine and runtime for StepFlow workflows.
+
+## Quick Start
+
+### Building
+
+```bash
+# Build the project
+cargo build
+
+# Build with optimizations
+cargo build --release
+```
+
+### Testing
+
+```bash
+# Run fast unit tests (no external dependencies)
+cargo test
+
+# Run tests for a specific crate
+cargo test -p stepflow-execution
+
+# Run a specific test
+cargo test -p stepflow-execution -- execute_flows
+
+# Run with snapshot tests and automatic snapshot updates
+cargo insta test --unreferenced=delete --review
+```
+
+For integration tests that require external dependencies (Python environment), use the scripts in the project root:
+
+```bash
+# Run integration tests (requires Python environment)
+cd ..
+./scripts/test-integration.sh
+
+# Run complete test suite (unit + Python SDK + integration)
+./scripts/test-all.sh
+```
+
+### Running Workflows
+
+```bash
+# Run a workflow with input file
+cargo run -- run --flow=examples/python/basic.yaml --input=examples/python/input1.json
+
+# Run with inline JSON input
+cargo run -- run --flow=examples/python/basic.yaml --input-json='{"m": 3, "n": 4}'
+
+# Run with inline YAML input
+cargo run -- run --flow=examples/python/basic.yaml --input-yaml='m: 2\nn: 7'
+
+# Run reading from stdin (JSON format)
+echo '{"m": 1, "n": 2}' | cargo run -- run --flow=examples/python/basic.yaml --format=json
+
+# Run with a custom config file
+cargo run -- run --flow=<flow.yaml> --input=<input.json> --config=<stepflow-config.yml>
+```
+
+### Running as a Service
+
+```bash
+# Start workflow service
+cargo run -- serve --port=7837 --config=<stepflow-config.yml>
+
+# Submit a workflow to running service
+cargo run -- submit --url=http://localhost:7837/api/v1 --flow=<flow.yaml> --input=<input.json>
+```
+
+### Code Quality
+
+```bash
+# Run linting
+cargo clippy
+
+# Auto-fix linting issues where possible
+cargo clippy --fix
+
+# Format code
+cargo fmt
+
+# Check compilation without building
+cargo check
+```
+
+## Project Structure
+
+This is a Rust workspace containing multiple crates:
+
+- **`stepflow-core`** - Core types and workflow definitions
+- **`stepflow-execution`** - Workflow execution engine
+- **`stepflow-plugin`** - Plugin system and interfaces
+- **`stepflow-protocol`** - JSON-RPC communication protocol
+- **`stepflow-builtins`** - Built-in component implementations
+- **`stepflow-components-mcp`** - MCP (Model Context Protocol) integration
+- **`stepflow-main`** - CLI and service binaries
+- **`stepflow-server`** - HTTP API server
+- **`stepflow-state`** - State storage interfaces and implementations
+- **`stepflow-state-sql`** - SQL-based state storage
+- **`stepflow-analysis`** - Workflow analysis and validation
+- **`stepflow-mock`** - Mock implementations for testing
+
+## Documentation
+
+For comprehensive documentation, examples, and guides, visit the [StepFlow Documentation](https://fuzzy-journey-4j3y1we.pages.github.io/).
+
+See also:
+- [CLAUDE.md](../CLAUDE.md) - Development guide for contributors
+- [Project README](../README.md) - Main project overview

--- a/stepflow-rs/crates/stepflow-main/tests/test_commands.rs
+++ b/stepflow-rs/crates/stepflow-main/tests/test_commands.rs
@@ -32,42 +32,6 @@ pub fn init_test_logging() {
     });
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_run_test_workflows() {
-    init_test_logging();
-
-    // Test the stepflow test command on our test directory
-    let test_path = std::path::Path::new("../../tests");
-    let test_options = stepflow_main::test::TestOptions {
-        cases: vec![],
-        update: false,
-        diff: false,
-    };
-
-    // This should find and run tests in the test directory
-    let result = stepflow_main::test::run_tests(test_path, None, test_options).await;
-
-    // The test should succeed (basic.yaml should pass, no_tests.yaml should be skipped)
-    let result = result.expect("Test command should succeed");
-    assert_eq!(result, 0);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_run_example_workflows() {
-    init_test_logging();
-
-    // Test the stepflow test command on our examples directory
-    let test_path = std::path::Path::new("../../../examples");
-    let test_options = stepflow_main::test::TestOptions {
-        cases: vec![],
-        update: false,
-        diff: false,
-    };
-
-    // This should find and run tests in the examples directory
-    let result = stepflow_main::test::run_tests(test_path, None, test_options).await;
-
-    // The test should succeed - all example workflows with test cases should pass
-    let result = result.expect("Example test command should succeed");
-    assert_eq!(result, 0);
-}
+// Integration test functions moved to scripts/test-integration.sh
+// These tests required external Python environment setup and are now run
+// as part of the integration test suite to keep unit tests fast.


### PR DESCRIPTION
Changes `ci.yml` to split actual logic into separate actions, and use the edited paths to control which tests run.

Introduces an integration test CI job which runs on changes to the core runtime (stepflow-rs) or the Python SDK (sdks/python).

Applies formatting and linting to the Python SDK (typechecking to-be-fixed in a later PR).

Removes the "run all the tests / examples" form Rust since that was covering a combination of Rust and Python, and uses the StepFlow binary in the integration job.