### PR TITLE
feat: Change component names URLs to paths

### DIFF
--- a/docs/docs/components/builtins.md
+++ b/docs/docs/components/builtins.md
@@ -8,7 +8,7 @@ StepFlow provides several built-in components that handle common workflow operat
 
 ## Data Storage Components
 
-### `builtin://put_blob`
+### `put_blob`
 
 Store JSON data as content-addressable blobs for efficient reuse across workflow steps.
 
@@ -35,7 +35,7 @@ output:
 ```yaml
 steps:
   - id: store_user_data
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         user_id: { $from: { workflow: input }, path: "user_id" }
@@ -43,7 +43,7 @@ steps:
         preferences: { $from: { step: load_preferences } }
 ```
 
-### `builtin://get_blob`
+### `get_blob`
 
 Retrieve JSON data from previously stored blobs.
 
@@ -70,7 +70,7 @@ output:
 ```yaml
 steps:
   - id: retrieve_user_data
-    component: builtin://get_blob
+    component: get_blob
     input:
       blob_id: { $from: { step: store_user_data }, path: "blob_id" }
 ```
@@ -84,7 +84,7 @@ steps:
 
 ## File Operations
 
-### `builtin://load_file`
+### `load_file`
 
 Load and parse files from the filesystem with automatic format detection.
 
@@ -124,12 +124,12 @@ output:
 ```yaml
 steps:
   - id: load_config
-    component: builtin://load_file
+    component: load_file
     input:
       path: "config/settings.yaml"
 
   - id: load_data
-    component: builtin://load_file
+    component: load_file
     input:
       path: { $from: { workflow: input }, path: "data_file" }
       format: "json"
@@ -137,7 +137,7 @@ steps:
 
 ## AI Integration Components
 
-### `builtin://create_messages`
+### `create_messages`
 
 Create structured chat message arrays for AI models from system instructions and user prompts.
 
@@ -170,13 +170,13 @@ output:
 ```yaml
 steps:
   - id: prepare_chat
-    component: builtin://create_messages
+    component: create_messages
     input:
       system_instructions: "You are an expert data analyst"
       user_prompt: { $from: { workflow: input }, path: "question" }
 ```
 
-### `builtin://openai`
+### `openai`
 
 Send messages to OpenAI's chat completion API and receive responses.
 
@@ -219,7 +219,7 @@ Each message must have:
 ```yaml
 steps:
   - id: ask_ai
-    component: builtin://openai
+    component: openai
     input:
       messages: { $from: { step: prepare_chat }, path: "messages" }
       max_tokens: 200
@@ -231,13 +231,13 @@ steps:
 ```yaml
 steps:
   - id: create_prompt
-    component: builtin://create_messages
+    component: create_messages
     input:
       system_instructions: "You are a code review assistant. Analyze code for potential issues."
       user_prompt: { $from: { workflow: input }, path: "code_snippet" }
 
   - id: analyze_code
-    component: builtin://openai
+    component: openai
     input:
       messages: { $from: { step: create_prompt }, path: "messages" }
       max_tokens: 500
@@ -246,7 +246,7 @@ steps:
 
 ## Workflow Composition
 
-### `builtin://eval`
+### `eval`
 
 Execute nested workflows with isolated execution contexts.
 
@@ -280,7 +280,7 @@ output:
 ```yaml
 steps:
   - id: run_analysis
-    component: builtin://eval
+    component: eval
     input:
       workflow:
         input_schema:

--- a/docs/docs/examples/basic-operations.md
+++ b/docs/docs/examples/basic-operations.md
@@ -38,7 +38,7 @@ output_schema:
 steps:
   # Step 1: Validate input data
   - id: validate_input
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -58,7 +58,7 @@ steps:
 
   # Step 2: Run validation
   - id: run_validation
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: validate_input }, path: "blob_id" }
       input:
@@ -66,7 +66,7 @@ steps:
 
   # Step 3: Transform data (only if validation passes)
   - id: transform_data
-    component: builtin://put_blob
+    component: put_blob
     skip: 
       $from: { step: run_validation }
       path: "is_valid"
@@ -91,7 +91,7 @@ steps:
 
   # Step 4: Execute transformation
   - id: execute_transform
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: transform_data }, path: "blob_id" }
       input:
@@ -180,7 +180,7 @@ input_schema:
 steps:
   # Load configuration with error handling
   - id: load_config
-    component: builtin://load_file
+    component: load_file
     on_error:
       action: continue
       default_output:
@@ -196,13 +196,13 @@ steps:
 
   # Load data file
   - id: load_data
-    component: builtin://load_file
+    component: load_file
     input:
       path: { $from: { workflow: input }, path: "data_file" }
 
   # Validate that we have required configuration
   - id: validate_config
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -223,7 +223,7 @@ steps:
 
   # Run configuration validation
   - id: check_config
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: validate_config }, path: "blob_id" }
       input:
@@ -231,7 +231,7 @@ steps:
 
   # Process data if configuration is valid
   - id: process_data
-    component: builtin://put_blob
+    component: put_blob
     skip:
       $from: { step: check_config }
       path: "is_valid"
@@ -265,7 +265,7 @@ steps:
 
   # Execute processing
   - id: execute_processing
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: process_data }, path: "blob_id" }
       input:
@@ -274,7 +274,7 @@ steps:
 
   # Format output according to requested format
   - id: format_output
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -302,7 +302,7 @@ steps:
 
   # Execute formatting
   - id: execute_formatting
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: format_output }, path: "blob_id" }
       input:
@@ -362,7 +362,7 @@ steps:
   
   # Process API sources
   - id: process_api_sources
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -386,7 +386,7 @@ steps:
 
   # Process file sources  
   - id: process_file_sources
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -410,7 +410,7 @@ steps:
 
   # Process database sources
   - id: process_database_sources
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -434,21 +434,21 @@ steps:
 
   # Execute all processing in parallel
   - id: execute_api_processing
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: process_api_sources }, path: "blob_id" }
       input:
         sources: { $from: { workflow: input }, path: "data_sources" }
 
   - id: execute_file_processing
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: process_file_sources }, path: "blob_id" }
       input:
         sources: { $from: { workflow: input }, path: "data_sources" }
 
   - id: execute_database_processing
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: process_database_sources }, path: "blob_id" }
       input:
@@ -456,7 +456,7 @@ steps:
 
   # Combine all results (waits for all parallel processing to complete)
   - id: combine_results
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -493,7 +493,7 @@ steps:
 
   # Execute combination
   - id: execute_combination
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: combine_results }, path: "blob_id" }
       input:
@@ -573,7 +573,7 @@ input_schema:
 steps:
   # Try primary API with retry logic
   - id: try_primary_api
-    component: http://get  # Future component
+    component: /http/get  # Future component
     on_error:
       action: continue
       default_output:
@@ -587,7 +587,7 @@ steps:
 
   # Try secondary API if primary fails
   - id: try_secondary_api
-    component: http://get  # Future component
+    component: /http/get  # Future component
     skip: { $from: { step: try_primary_api }, path: "success" }
     on_error:
       action: continue
@@ -602,7 +602,7 @@ steps:
 
   # Use fallback data if all APIs fail
   - id: use_fallback_data
-    component: builtin://put_blob
+    component: put_blob
     skip:
       # Skip if either API succeeded
       # This would need custom logic to check if ANY API succeeded
@@ -614,7 +614,7 @@ steps:
 
   # Combine results from whichever source succeeded
   - id: combine_results
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -647,7 +647,7 @@ steps:
 
   # Execute result combination
   - id: execute_combination
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: combine_results }, path: "blob_id" }
       input:

--- a/docs/docs/examples/custom-components.md
+++ b/docs/docs/examples/custom-components.md
@@ -251,7 +251,7 @@ input_schema:
 steps:
   # Use custom HTTP component
   - id: fetch_api_data
-    component: my_components://http_request
+    component: /my_components/http_request
     input:
       url: { $from: { workflow: input }, path: "api_url" }
       method: "GET"
@@ -260,7 +260,7 @@ steps:
 
   # Process data with custom component
   - id: process_user_data
-    component: my_components://process_data
+    component: /my_components/process_data
     input:
       data: { $from: { workflow: input }, path: "user_data" }
       processing_rules:
@@ -269,7 +269,7 @@ steps:
 
   # Cache the results
   - id: cache_results
-    component: my_components://cache_data
+    component: /my_components/cache_data
     input:
       key: "processed_user_data"
       data:
@@ -1025,7 +1025,7 @@ input_schema:
 
 steps:
   - id: process_test_data
-    component: my_components://process_data
+    component: /my_components/process_data
     input:
       data: { $from: { workflow: input }, path: "test_data" }
       processing_rules:
@@ -1033,14 +1033,14 @@ steps:
       include_metadata: true
 
   - id: cache_processed_data
-    component: my_components://cache_data
+    component: /my_components/cache_data
     input:
       key: "integration_test"
       data: { $from: { step: process_test_data } }
       ttl_minutes: 5
 
   - id: retrieve_cached_data
-    component: my_components://retrieve_cache
+    component: /my_components/retrieve_cache
     input:
       blob_id: { $from: { step: cache_processed_data }, path: "blob_id" }
 

--- a/docs/docs/examples/data-processing.md
+++ b/docs/docs/examples/data-processing.md
@@ -12,10 +12,10 @@ A comprehensive Extract, Transform, Load pipeline with validation and error hand
 
 :::info Future Components
 This example uses several planned future components:
-- `database://query` - SQL database operations
-- `csv://parse` - CSV file parsing
-- `http://post` - HTTP POST requests
-- `validation://schema` - Data schema validation
+- `/database/query` - SQL database operations
+- `/csv/parse` - CSV file parsing
+- `/http/post` - HTTP POST requests
+- `/validation/schema` - Data schema validation
 
 Currently, you can achieve similar functionality using custom Python components with libraries like `pandas`, `sqlalchemy`, and `requests`.
 :::
@@ -46,7 +46,7 @@ steps:
 
   # Extract sales data from database
   - id: extract_sales_data
-    component: database://query  # Future component
+    component: /database/query  # Future component
     on_error:
       action: continue
       default_output:
@@ -71,7 +71,7 @@ steps:
 
   # Extract customer data from CSV file
   - id: extract_customer_data
-    component: csv://parse  # Future component
+    component: /csv/parse  # Future component
     on_error:
       action: continue
       default_output:
@@ -86,7 +86,7 @@ steps:
 
   # Extract product data from API
   - id: extract_product_data
-    component: http://get  # Future component
+    component: /http/get  # Future component
     on_error:
       action: continue
       default_output:
@@ -104,7 +104,7 @@ steps:
 
   # Validate sales data structure
   - id: validate_sales_data
-    component: validation://schema  # Future component
+    component: /validation/schema  # Future component
     input:
       data: { $from: { step: extract_sales_data }, path: "data" }
       schema:
@@ -123,7 +123,7 @@ steps:
 
   # Create data quality report
   - id: create_quality_report
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -179,7 +179,7 @@ steps:
 
   # Execute quality report
   - id: execute_quality_report
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: create_quality_report }, path: "blob_id" }
       input:
@@ -192,7 +192,7 @@ steps:
 
   # Transform and enrich sales data
   - id: transform_sales_data
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -261,7 +261,7 @@ steps:
 
   # Execute sales transformation
   - id: execute_sales_transformation
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: transform_sales_data }, path: "blob_id" }
       input:
@@ -273,7 +273,7 @@ steps:
 
   # Prepare data for loading
   - id: prepare_warehouse_load
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -309,7 +309,7 @@ steps:
 
   # Execute load preparation
   - id: execute_load_preparation
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: prepare_warehouse_load }, path: "blob_id" }
       input:
@@ -318,7 +318,7 @@ steps:
 
   # Load data to warehouse
   - id: load_to_warehouse
-    component: database://bulk_insert  # Future component
+    component: /database/bulk_insert  # Future component
     on_error:
       action: continue
       default_output:
@@ -334,7 +334,7 @@ steps:
 
   # Create final ETL report
   - id: create_etl_report
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -399,7 +399,7 @@ steps:
 
   # Execute ETL report creation
   - id: execute_etl_report
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: create_etl_report }, path: "blob_id" }
       input:
@@ -430,9 +430,9 @@ test:
 
 :::info Future Components
 This example demonstrates a real-time processing pattern using planned components:
-- `stream://kafka_consumer` - Kafka message consumption
-- `cache://redis` - Redis caching operations
-- `metrics://publish` - Metrics publication
+- `/stream/kafka_consumer` - Kafka message consumption
+- `/cache/redis` - Redis caching operations
+- `/metrics/publish` - Metrics publication
 
 These can be implemented today using custom Python components with appropriate libraries.
 :::
@@ -461,7 +461,7 @@ input_schema:
 steps:
   # Consume events from Kafka stream
   - id: consume_events
-    component: stream://kafka_consumer  # Future component
+    component: /stream/kafka_consumer  # Future component
     input:
       bootstrap_servers: { $from: { workflow: input }, path: "stream_config.kafka_bootstrap_servers" }
       topic: { $from: { workflow: input }, path: "stream_config.topic_name" }
@@ -471,7 +471,7 @@ steps:
 
   # Parse and validate incoming events
   - id: parse_events
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -532,7 +532,7 @@ steps:
 
   # Execute event parsing
   - id: execute_event_parsing
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: parse_events }, path: "blob_id" }
       input:
@@ -540,7 +540,7 @@ steps:
 
   # Real-time analytics and aggregation
   - id: calculate_real_time_metrics
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -618,7 +618,7 @@ steps:
 
   # Execute real-time analytics
   - id: execute_real_time_analytics
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: calculate_real_time_metrics }, path: "blob_id" }
       input:
@@ -627,7 +627,7 @@ steps:
 
   # Cache metrics for dashboard
   - id: cache_metrics
-    component: cache://redis  # Future component
+    component: /cache/redis  # Future component
     on_error:
       action: continue
       default_output:
@@ -641,7 +641,7 @@ steps:
 
   # Publish metrics to monitoring system
   - id: publish_metrics
-    component: metrics://publish  # Future component
+    component: /metrics/publish  # Future component
     input:
       metrics:
         - name: "events_processed_total"
@@ -659,7 +659,7 @@ steps:
 
   # Send alerts if enabled
   - id: send_alerts
-    component: notifications://slack  # Future component
+    component: /notifications/slack  # Future component
     skip:
       # Skip if no alerts or alerts disabled
       # This would check: !input.processing_rules.enable_real_time_alerts OR len(alerts) == 0
@@ -713,7 +713,7 @@ input_schema:
 steps:
   # Profile each dataset in parallel
   - id: profile_dataset_1
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -757,7 +757,7 @@ steps:
 
   # Execute dataset profiling for first dataset
   - id: execute_dataset_1_profiling
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: profile_dataset_1 }, path: "blob_id" }
       input:
@@ -765,7 +765,7 @@ steps:
 
   # Apply quality rules to dataset
   - id: apply_quality_rules
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -863,7 +863,7 @@ steps:
 
   # Execute quality rule application
   - id: execute_quality_rules
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: apply_quality_rules }, path: "blob_id" }
       input:
@@ -872,7 +872,7 @@ steps:
 
   # Generate quality dashboard data
   - id: generate_dashboard_data
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -926,7 +926,7 @@ steps:
 
   # Execute dashboard generation
   - id: execute_dashboard_generation
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: generate_dashboard_data }, path: "blob_id" }
       input:

--- a/docs/docs/examples/mcp-tools.md
+++ b/docs/docs/examples/mcp-tools.md
@@ -49,7 +49,7 @@ plugins:
 
 ## Using MCP Tools in Workflows
 
-MCP tools are referenced using the format `plugin_name://tool_name`:
+MCP tools are referenced using the format `/plugin_name/tool_name`:
 
 ```yaml
 name: file_processing
@@ -64,20 +64,20 @@ inputs:
 steps:
   # Write content to a file
   - name: save_content
-    component: fs://write_file
+    component: /fs/write_file
     inputs:
       path: /tmp/workspace/output.txt
       content: ${{ inputs.content }}
   
   # Read the file back
   - name: verify_content
-    component: fs://read_file
+    component: /fs/read_file
     inputs:
       path: /tmp/workspace/output.txt
   
   # List directory contents
   - name: list_files
-    component: fs://list_directory
+    component: /fs/list_directory
     inputs:
       path: /tmp/workspace
 
@@ -108,7 +108,7 @@ inputs:
 steps:
   # Create a working directory
   - name: setup_workspace
-    component: fs://create_directory
+    component: /fs/create_directory
     inputs:
       path: /tmp/workspace/docs
   
@@ -118,7 +118,7 @@ steps:
     iteratorName: doc
     steps:
       - name: write_doc
-        component: fs://write_file
+        component: /fs/write_file
         inputs:
           path: /tmp/workspace/docs/${{ doc.name }}.txt
           content: ${{ doc.content }}
@@ -136,14 +136,14 @@ steps:
   
   # Save the index
   - name: save_index
-    component: fs://write_file
+    component: /fs/write_file
     inputs:
       path: /tmp/workspace/docs/index.md
       content: ${{ steps.create_index }}
   
   # List all created files
   - name: list_output
-    component: fs://list_directory
+    component: /fs/list_directory
     inputs:
       path: /tmp/workspace/docs
 
@@ -193,7 +193,7 @@ version: "1.0"
 steps:
   # This will fail but show available tools in the error message
   - name: discover
-    component: fs://unknown_tool
+    component: /fs/unknown_tool
     inputs: {}
 ```
 
@@ -206,7 +206,7 @@ MCP tools can return two types of errors:
 1. **Tool Errors**: Expected failures (e.g., file not found)
    ```yaml
    - name: read_config
-     component: fs://read_file
+     component: /fs/read_file
      inputs:
        path: /tmp/workspace/config.json
      continueOnError: true
@@ -256,7 +256,7 @@ Use `continueOnError` and conditional steps for graceful error handling:
 
 ```yaml
 - name: try_operation
-  component: mcp_tool://operation
+  component: /mcp_tool/operation
   continueOnError: true
 
 - name: fallback
@@ -313,7 +313,7 @@ steps:
   iteratorName: file
   steps:
     - name: write
-      component: fs://write_file
+      component: /fs/write_file
       inputs:
         path: /tmp/workspace/${{ file.name }}
         content: ${{ file.content }}

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -73,7 +73,7 @@ output_schema:
 steps:
   # Store the context as a blob for potential reuse
   - id: store_context
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         context: { $from: { workflow: input }, path: "context" }
@@ -81,7 +81,7 @@ steps:
 
     # Format the context and question into a clear prompt
   - id: format_prompt
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         context: { $from: { workflow: input }, path: "context" }
@@ -89,20 +89,20 @@ steps:
 
   # Get the formatted prompt from the blob
   - id: get_prompt
-    component: builtin://get_blob
+    component: get_blob
     input:
       blob_id: { $from: { step: format_prompt }, path: "blob_id" }
 
   # Create messages for OpenAI
   - id: create_messages
-    component: builtin://create_messages
+    component: create_messages
     input:
       system_instructions: "You are a helpful assistant. Answer the user's question based on the provided context. If the context doesn't contain enough information, say so and provide your best general answer."
       user_prompt: { $from: { step: get_prompt }, path: "$.data.question" }
 
   # Generate AI response using OpenAI  
   - id: generate_answer
-    component: builtin://openai
+    component: openai
     input:
       messages: { $from: { step: create_messages }, path: "messages" }
       temperature: 0.3
@@ -110,7 +110,7 @@ steps:
 
   # Create response metadata
   - id: create_metadata
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         processed_at: "2024-01-15T10:30:00Z"
@@ -168,9 +168,9 @@ You should see output with the `answer` and `metadata` properties as defined in 
 This AI Q&A workflow demonstrates several key StepFlow concepts:
 
 - **Input/Output Schemas**: Define the structure of questions, context, and answers
-- **AI Integration**: Use [`builtin://openai`](./components/builtins.md#builtinopenai) and [`builtin://create_messages`](./components/builtins.md#builtincreate_messages) for natural language processing
+- **AI Integration**: Use [`openai`](./components/builtins.md#builtinopenai) and [`create_messages`](./components/builtins.md#builtincreate_messages) for natural language processing
 - **Data References**: Use [`$from`](./workflows/expressions.md#data-references-from) to pass data between steps
-- **Blob Storage**: Store context and metadata for reuse with [`builtin://put_blob`](./components/builtins.md#builtinput_blob)
+- **Blob Storage**: Store context and metadata for reuse with [`put_blob`](./components/builtins.md#builtinput_blob)
 - **Multi-step Processing**: Orchestrate data storage, prompt formatting, and AI generation
 
 The workflow follows this pattern:
@@ -252,8 +252,8 @@ You've just built a simple AI Q&A application! Check out the `examples/` directo
 ### AI-Free Workflows
 
 The example above requires an OpenAI API key. For workflows that don't require AI, you can use:
-- Data transformation workflows with just `builtin://put_blob`
-- HTTP API integrations with `builtin://http_request`
+- Data transformation workflows with just `put_blob`
+- HTTP API integrations with `http_request`
 - File processing and validation workflows
 
 ### Key Concepts to Explore

--- a/docs/docs/runtime/config.md
+++ b/docs/docs/runtime/config.md
@@ -62,12 +62,12 @@ plugins:
 ```
 
 **Available Components:**
-- `builtin://openai` - OpenAI API integration
-- `builtin://create_messages` - Chat message creation
-- `builtin://eval` - Nested workflow execution
-- `builtin://put_blob` - Store data as blobs
-- `builtin://get_blob` - Retrieve blob data
-- `builtin://load_file` - Load and parse files
+- `openai` - OpenAI API integration
+- `create_messages` - Chat message creation
+- `eval` - Nested workflow execution
+- `put_blob` - Store data as blobs
+- `get_blob` - Retrieve blob data
+- `load_file` - Load and parse files
 
 #### Stdio Plugins
 
@@ -107,12 +107,12 @@ plugins:
 
 ### Component URLs
 
-Components are referenced by URL format: `<plugin_name>://<component_name>`
+Components are referenced by path format: `<component_name>` for builtin components or `/<plugin_name>/<component_name>` for plugin components
 
 ```yaml
 steps:
   - id: my_step
-    component: python://my_component
+    component: /python/my_component
     input: { }
 ```
 
@@ -129,7 +129,7 @@ plugins:
 ```
 
 This plugin enables components like:
-- `python://udf` - Execute user-defined Python functions
+- `/python/udf` - Execute user-defined Python functions
 - Custom components defined in your Python project
 
 ### MCP Integration
@@ -144,7 +144,7 @@ plugins:
     args: ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/directory"]
 ```
 
-MCP tools are accessed with format: `mcp+stdio://server/tool_name`
+MCP tools are accessed with format: `/server/tool_name`
 
 ## State Store Configuration
 
@@ -293,7 +293,7 @@ StepFlow respects these environment variables:
 
 ### Component-Specific
 
-- **`OPENAI_API_KEY`**: OpenAI API key for `builtin://openai` component
+- **`OPENAI_API_KEY`**: OpenAI API key for `openai` component
 - **`PYTHONPATH`**: Python path for Python components
 - **Custom variables**: Passed through to component servers via plugin configuration
 

--- a/examples/basic/workflow.yaml
+++ b/examples/basic/workflow.yaml
@@ -27,7 +27,7 @@ output_schema:
 steps:
   # Create UDF for addition
   - id: create_addition_udf
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -40,7 +40,7 @@ steps:
 
   # Create UDF for multiplication  
   - id: create_multiplication_udf
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -53,7 +53,7 @@ steps:
 
   # Calculate m + n using UDF
   - id: m_plus_n
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: create_addition_udf }, path: "blob_id" }
       input:
@@ -62,7 +62,7 @@ steps:
 
   # Calculate m * n using UDF
   - id: m_times_n
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: create_multiplication_udf }, path: "blob_id" }
       input:
@@ -71,7 +71,7 @@ steps:
 
   # Calculate (m + n) * n using UDF
   - id: m_plus_n_times_n
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: create_multiplication_udf }, path: "blob_id" }
       input:

--- a/examples/custom-python-components/README.md
+++ b/examples/custom-python-components/README.md
@@ -67,8 +67,8 @@ cargo run -- test ../examples/custom-python-components/workflow.yaml --config=..
 
 The workflow will:
 
-1. **Analyze customer data** using the `custom://analyze_customers` component
-2. **Generate a business report** using the `custom://generate_report` component  
+1. **Analyze customer data** using the `/custom/analyze_customers` component
+2. **Generate a business report** using the `/custom/generate_report` component  
 3. **Store the report as a blob** and return a summary
 
 Sample output structure:
@@ -130,12 +130,12 @@ Components are registered using the `@server.component` decorator, which:
 
 ### 3. Workflow Integration
 
-The workflow uses the custom components via the `custom://` protocol:
+The workflow uses the custom components via the `/custom/` path:
 
 ```yaml
 steps:
   - id: analyze_customer_data
-    component: custom://analyze_customers
+    component: "/custom/analyze_customers"
     input:
       customers: { $from: { workflow: input }, path: "customers" }
       orders: { $from: { workflow: input }, path: "orders" }

--- a/examples/custom-python-components/workflow.yaml
+++ b/examples/custom-python-components/workflow.yaml
@@ -28,19 +28,19 @@ input_schema:
 
 steps:
   - id: analyze_customer_data
-    component: custom://analyze_customers
+    component: "/custom/analyze_customers"
     input:
       customers: { $from: { workflow: input }, path: "customers" }
       orders: { $from: { workflow: input }, path: "orders" }
 
   - id: generate_business_report
-    component: custom://generate_report
+    component: "/custom/generate_report"
     input:
       analysis: { $from: { step: analyze_customer_data } }
       report_title: "Q4 Customer Analysis Report"
 
   - id: retrieve_report
-    component: builtin://get_blob
+    component: "get_blob"
     input:
       blob_id: { $from: { step: generate_business_report }, path: "report_blob_id" }
 

--- a/examples/data-pipeline/debug-pipeline.yaml
+++ b/examples/data-pipeline/debug-pipeline.yaml
@@ -14,56 +14,56 @@ input_schema:
 steps:
   # Parallel data processing steps
   - id: sum_revenue_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data'])"
 
   - id: calculate_total_revenue
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: sum_revenue_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: count_sales_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "len(input['sales_data'])"
 
   - id: count_sales
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: count_sales_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: average_sale_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data']) / len(input['sales_data']) if input['sales_data'] else 0"
 
   - id: calculate_average_sale
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: average_sale_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: divide_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "input['a'] / input['b'] if input['b'] != 0 else 0"
 
   - id: calculate_performance_ratio
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: divide_udf }, path: "blob_id" }
       input:
@@ -72,7 +72,7 @@ steps:
 
   # Format metrics summary for display
   - id: format_metrics_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
@@ -98,7 +98,7 @@ steps:
             Focus on actionable business insights that would help a sales manager make strategic decisions."""
 
   - id: format_metrics_summary
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: format_metrics_udf }, path: "blob_id" }
       input:

--- a/examples/data-pipeline/pipeline.yaml
+++ b/examples/data-pipeline/pipeline.yaml
@@ -14,42 +14,42 @@ input_schema:
 steps:
   # Parallel data processing steps
   - id: sum_revenue_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data'])"
 
   - id: calculate_total_revenue
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: sum_revenue_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: count_sales_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "len(input['sales_data'])"
 
   - id: count_sales
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: count_sales_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: average_sale_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data']) / len(input['sales_data']) if input['sales_data'] else 0"
 
   - id: calculate_average_sale
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: average_sale_udf }, path: "blob_id" }
       input:
@@ -57,14 +57,14 @@ steps:
 
   # This step waits for total_revenue to complete
   - id: divide_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "input['a'] / input['b'] if input['b'] != 0 else 0"
 
   - id: calculate_performance_ratio
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: divide_udf }, path: "blob_id" }
       input:
@@ -73,49 +73,49 @@ steps:
 
   # Regional analysis using eval components (run in parallel)
   - id: analyze_west_region
-    component: "builtin://eval"
+    component: "eval"
     input:
       workflow:
         $literal:
           name: "West Region Analysis"
           steps:
             - id: filter_west_udf
-              component: "builtin://put_blob"
+              component: "put_blob"
               input:
                 data:
                   $literal:
                     code: "[item for item in input['sales_data'] if item.get('region') == 'West']"
 
             - id: filter_region
-              component: python://udf
+              component: "/python/udf"
               input:
                 blob_id: { $from: { step: filter_west_udf }, path: "blob_id" }
                 input:
                   sales_data: { $from: { workflow: input }, path: "sales_data" }
 
             - id: west_revenue_udf
-              component: "builtin://put_blob"
+              component: "put_blob"
               input:
                 data:
                   $literal:
                     code: "sum(item['revenue'] for item in input['filtered_data'])"
 
             - id: region_revenue
-              component: python://udf
+              component: "/python/udf"
               input:
                 blob_id: { $from: { step: west_revenue_udf }, path: "blob_id" }
                 input:
                   filtered_data: { $from: { step: filter_region }, path: "result" }
 
             - id: west_count_udf
-              component: "builtin://put_blob"
+              component: "put_blob"
               input:
                 data:
                   $literal:
                     code: "len(input['filtered_data'])"
 
             - id: region_count
-              component: python://udf
+              component: "/python/udf"
               input:
                 blob_id: { $from: { step: west_count_udf }, path: "blob_id" }
                 input:
@@ -129,49 +129,49 @@ steps:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: analyze_east_region
-    component: "builtin://eval"
+    component: "eval"
     input:
       workflow:
         $literal:
           name: "East Region Analysis"
           steps:
             - id: filter_east_udf
-              component: "builtin://put_blob"
+              component: "put_blob"
               input:
                 data:
                   $literal:
                     code: "[item for item in input['sales_data'] if item.get('region') == 'East']"
 
             - id: filter_region
-              component: python://udf
+              component: "/python/udf"
               input:
                 blob_id: { $from: { step: filter_east_udf }, path: "blob_id" }
                 input:
                   sales_data: { $from: { workflow: input }, path: "sales_data" }
 
             - id: east_revenue_udf
-              component: "builtin://put_blob"
+              component: "put_blob"
               input:
                 data:
                   $literal:
                     code: "sum(item['revenue'] for item in input['filtered_data'])"
 
             - id: region_revenue
-              component: python://udf
+              component: "/python/udf"
               input:
                 blob_id: { $from: { step: east_revenue_udf }, path: "blob_id" }
                 input:
                   filtered_data: { $from: { step: filter_region }, path: "result" }
 
             - id: east_count_udf
-              component: "builtin://put_blob"
+              component: "put_blob"
               input:
                 data:
                   $literal:
                     code: "len(input['filtered_data'])"
 
             - id: region_count
-              component: python://udf
+              component: "/python/udf"
               input:
                 blob_id: { $from: { step: east_count_udf }, path: "blob_id" }
                 input:
@@ -186,7 +186,7 @@ steps:
 
   # Compare regional performance
   - id: compare_regions_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
@@ -207,7 +207,7 @@ steps:
             }
 
   - id: compare_regions
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: compare_regions_udf }, path: "blob_id" }
       input:
@@ -216,7 +216,7 @@ steps:
 
   # Format metrics for AI analysis (waits for all calculations)
   - id: format_metrics_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
@@ -238,7 +238,7 @@ steps:
             Please provide strategic insights and recommendations based on this data."""
 
   - id: format_metrics_summary
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: format_metrics_udf }, path: "blob_id" }
       input:
@@ -251,14 +251,14 @@ steps:
 
   # Format messages for OpenAI (depends on metrics summary)
   - id: create_openai_messages
-    component: "builtin://create_messages"
+    component: "create_messages"
     input:
       system_instructions: "You are a senior sales analyst providing insights based on business metrics and regional performance. Be specific and actionable in your recommendations."
       user_prompt: { $from: { step: format_metrics_summary }, path: "summary" }
 
   # Generate AI insights from the comprehensive metrics
   - id: generate_ai_insights
-    component: "builtin://openai"
+    component: "openai"
     input:
       messages: { $from: { step: create_openai_messages }, path: "messages" }
 

--- a/examples/eval/README.md
+++ b/examples/eval/README.md
@@ -1,10 +1,10 @@
 # Eval Component Examples
 
-This directory demonstrates the `builtin://eval` component, which enables **nested workflow execution** within StepFlow. The eval component allows you to define complete workflows as steps, enabling powerful composition and reusability patterns.
+This directory demonstrates the `eval` component, which enables **nested workflow execution** within StepFlow. The eval component allows you to define complete workflows as steps, enabling powerful composition and reusability patterns.
 
 ## What is the Eval Component?
 
-The `builtin://eval` component executes a nested workflow with its own steps, inputs, and outputs. This enables:
+The `eval` component executes a nested workflow with its own steps, inputs, and outputs. This enables:
 
 - **Workflow Composition**: Build complex workflows from simpler, reusable sub-workflows
 - **Isolation**: Each nested workflow runs independently with its own execution context
@@ -51,7 +51,7 @@ cargo run -- run \
 **Purpose**: Tests the built-in component registry, specifically the `create_messages` component.
 
 **What it demonstrates**:
-- Using the `builtin://create_messages` component
+- Using the `create_messages` component
 - Proper input/output structure for builtin components
 
 **Run it**:
@@ -149,7 +149,7 @@ The examples have been updated to use the correct workflow syntax:
 ```yaml
 steps:
   - id: my_eval_step
-    component: "builtin://eval"
+    component: "eval"
     input:  # Not 'args'
       workflow:
         $literal:  # Required for inline workflow definitions
@@ -169,7 +169,7 @@ output:  # Not 'outputs'
 
 1. **"Component not found" errors**
    - Make sure the builtin plugin is registered in your config
-   - Verify the component URLs (e.g., `builtin://eval`)
+   - Verify the component paths (e.g., `eval`)
 
 2. **"Nested flow execution was cancelled" errors**
    - Check that output references use the correct format
@@ -192,19 +192,19 @@ Once you've verified the basic examples work, you can use eval components for:
 ### Regional Analysis Pattern
 ```yaml
 - id: analyze_region
-  component: "builtin://eval"
+  component: "eval"
   input:
     workflow:
       $literal:
         steps:
           - id: filter_data
-            component: python://filter_by_field
+            component: "/python/filter_by_field"
             input:
               data: { $from: { workflow: input }, path: "sales_data" }
               field: "region"
               value: { $from: { workflow: input }, path: "region_name" }
           - id: calculate_metrics
-            component: python://sum_field
+            component: "/python/sum_field"
             input:
               data: { $from: { step: filter_data }, path: "filtered_data" }
               field: "revenue"
@@ -218,7 +218,7 @@ Once you've verified the basic examples work, you can use eval components for:
 ### Dynamic Workflow Generation
 ```yaml
 - id: process_all_regions
-  component: "builtin://eval"
+  component: "eval"
   input:
     workflow: { $from: { step: generate_region_workflow }, path: "workflow_def" }
     input: { $from: { step: prepare_region_data }, path: "data" }

--- a/examples/eval/math-eval.yaml
+++ b/examples/eval/math-eval.yaml
@@ -9,14 +9,14 @@ input_schema:
 
 steps:
   - id: nested_math
-    component: "builtin://eval"
+    component: "eval"
     input:
       workflow:
         $literal:
           name: "Nested Math Workflow"
           steps:
             - id: add_udf
-              component: "builtin://put_blob"
+              component: "put_blob"
               input:
                 data:
                   $literal:
@@ -29,7 +29,7 @@ steps:
                     code: "input['a'] + input['b']"
             
             - id: compute_sum
-              component: python://udf
+              component: "/python/udf"
               input:
                 blob_id: { $from: { step: add_udf }, path: "blob_id" }
                 input:

--- a/examples/eval/simple-eval.yaml
+++ b/examples/eval/simple-eval.yaml
@@ -3,7 +3,7 @@ description: "Basic test of the eval builtin component"
 
 steps:
   - id: test_eval
-    component: "builtin://eval"
+    component: "eval"
     input:
       workflow:
         $literal:

--- a/examples/eval/test-builtins.yaml
+++ b/examples/eval/test-builtins.yaml
@@ -2,7 +2,7 @@ name: "Test Builtins Registry"
 
 steps:
   - id: test_create_messages
-    component: "builtin://create_messages"
+    component: "create_messages"
     input:
       system_instructions: "You are a test assistant"
       user_prompt: "Say hello"

--- a/examples/file-loading/load-pipeline.yaml
+++ b/examples/file-loading/load-pipeline.yaml
@@ -14,20 +14,20 @@ input_schema:
 steps:
   # Load the sales data from file
   - id: load_sales_data
-    component: "builtin://load_file"
+    component: "load_file"
     input:
       path: { $from: "$input", path: "data_file_path" }
 
   # Extract the sales_data array using UDF
   - id: extract_sales_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "input['file_data']['sales_data']"
 
   - id: extract_sales_array
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: extract_sales_udf }, path: "blob_id" }
       input:
@@ -35,56 +35,56 @@ steps:
 
   # Now process the sales data array
   - id: sum_revenue_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data'])"
 
   - id: calculate_total_revenue
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: sum_revenue_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { step: "extract_sales_array" }, path: "result" }
 
   - id: count_sales_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "len(input['sales_data'])"
 
   - id: count_sales
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: count_sales_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { step: "extract_sales_array" }, path: "result" }
 
   - id: average_sale_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "sum(item['revenue'] for item in input['sales_data']) / len(input['sales_data']) if input['sales_data'] else 0"
 
   - id: calculate_average_sale
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: average_sale_udf }, path: "blob_id" }
       input:
         sales_data: { $from: { step: "extract_sales_array" }, path: "result" }
 
   - id: divide_udf
-    component: "builtin://put_blob"
+    component: "put_blob"
     input:
       data:
         $literal:
           code: "input['a'] / input['b'] if input['b'] != 0 else 0"
 
   - id: calculate_performance_ratio
-    component: python://udf
+    component: "/python/udf"
     input:
       blob_id: { $from: { step: divide_udf }, path: "blob_id" }
       input:

--- a/examples/file-loading/test-load.yaml
+++ b/examples/file-loading/test-load.yaml
@@ -3,7 +3,7 @@ description: "Simple test of the load_file component"
 
 steps:
   - id: load_sales_data
-    component: "builtin://load_file"
+    component: "load_file"
     input:
       path: "test-data.json"
 

--- a/examples/mcp-component/README.md
+++ b/examples/mcp-component/README.md
@@ -28,18 +28,18 @@ cargo run -- run --flow=../examples/mcp-component/basic.yaml --input=../examples
 3. **Read the File**: Uses the MCP `read_file` tool to read back the created file
 4. **List Directory**: Uses the MCP `list_directory` tool to show all files in the `/tmp` directory
 
-## Understanding MCP Component URLs
+## Understanding MCP Component Paths
 
-MCP tools are referenced using StepFlow's plugin-based URL format:
+MCP tools are referenced using StepFlow's plugin-based path format:
 ```
-plugin_name://tool_name
+/plugin_name/tool_name
 ```
 
-Where `plugin_name` corresponds to the name configured in the StepFlow config file. This follows StepFlow's standard plugin architecture where each plugin registers with a name that becomes the protocol.
+Where `plugin_name` corresponds to the name configured in the StepFlow config file. This follows StepFlow's standard plugin architecture where each plugin registers with a name that becomes part of the path.
 
 For example:
-- `filesystem://write_file` - The `write_file` tool from the `filesystem` MCP server
-- `filesystem://read_file` - The `read_file` tool from the `filesystem` MCP server
+- `/filesystem/write_file` - The `write_file` tool from the `filesystem` MCP server
+- `/filesystem/read_file` - The `read_file` tool from the `filesystem` MCP server
 
 ## Expected Output
 
@@ -66,7 +66,7 @@ You can add additional MCP servers to the configuration. For example, to add a B
 Then use it in workflows like:
 ```yaml
 search_step:
-  component: "brave-search://brave_web_search"
+  component: "/brave-search/brave_web_search"
   input:
     query: "StepFlow workflow engine"
 ```

--- a/examples/mcp-component/basic.yaml
+++ b/examples/mcp-component/basic.yaml
@@ -18,20 +18,20 @@ input:
 steps:
   # Step 1: Create a file using MCP filesystem tool
   - id: create_file
-    component: "filesystem://write_file"
+    component: "/filesystem/write_file"
     input:
       path: { $from: { workflow: input }, path: "filename" }
       content: { $from: { workflow: input }, path: "content" }
 
   # Step 2: Read the file back to verify it was created
   - id: read_file
-    component: "filesystem://read_file"
+    component: "/filesystem/read_file"
     input:
       path: { $from: { workflow: input }, path: "filename" }
 
   # Step 3: List files in the directory to show the created file
   - id: list_directory
-    component: "filesystem://list_directory"
+    component: "/filesystem/list_directory"
     input:
       path: "/tmp"
 

--- a/examples/openai/openai_chat.yaml
+++ b/examples/openai/openai_chat.yaml
@@ -12,13 +12,13 @@ inputs:
 
 steps:
   - id: create_messages
-    component: "builtin://create_messages"
+    component: "create_messages"
     input:
       system_instructions: { $from: { workflow: input }, path: system_message }
       user_prompt: { $from: { workflow: input }, path: prompt }
 
   - id: send_message
-    component: "builtin://openai"
+    component: "openai"
     input:
       messages: { $from: { step: create_messages }, path: messages }
 

--- a/schemas/flow.json
+++ b/schemas/flow.json
@@ -147,16 +147,8 @@
       ]
     },
     "Component": {
-      "description": "Identifies a specific plugin and atomic functionality to execute.",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "string",
-          "format": "uri"
-        }
-      ]
+      "description": "Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf').",
+      "type": "string"
     },
     "Expr": {
       "description": "An expression that can be either a literal value or a template expression.",

--- a/schemas/protocol.json
+++ b/schemas/protocol.json
@@ -132,16 +132,8 @@
       ]
     },
     "Component": {
-      "description": "Identifies a specific plugin and atomic functionality to execute.",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "string",
-          "format": "uri"
-        }
-      ]
+      "description": "Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf').",
+      "type": "string"
     },
     "Value": {
       "description": "Any JSON value (object, array, string, number, boolean, or null)"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -70,8 +70,6 @@ cmd = "uv run python generate.py --check"
 help = "Regenerate types from schemas"
 sequence = [
     {cmd = "uv run python generate.py"},
-    {cmd = "uvx ${RUFF} format src/stepflow_sdk/generated_*.py"},
-    {cmd = "uvx ${RUFF} check --fix src/stepflow_sdk/generated_*.py"}
 ]
 
 [tool.poe.tasks.test]
@@ -116,7 +114,7 @@ docstring-code-format = true
 exclude = ["**/generated_*.py"]
 
 [tool.deptry]
-# types-* packages are type stubs for mypy and not directly imported  
+# types-* packages are type stubs for mypy and not directly imported
 ignore = ["DEP002"]
 extend_exclude = ["types-jsonschema"]
 

--- a/sdks/python/src/stepflow_sdk/flow_builder.py
+++ b/sdks/python/src/stepflow_sdk/flow_builder.py
@@ -180,7 +180,7 @@ class FlowBuilder:
         self,
         *,
         id: str,
-        component: str | Component,
+        component: Component,
         input_data: Valuable | None = None,
         input_schema: dict[str, Any] | Schema | None = None,
         output_schema: dict[str, Any] | Schema | None = None,
@@ -188,9 +188,8 @@ class FlowBuilder:
         on_error: ErrorAction | None = None,
     ) -> StepHandle:
         """Add a step to the flow."""
-        # Convert component to Component type
-        if isinstance(component, str):
-            component = Component(component)
+        # Component is now just a string, no conversion needed
+        # component is already the correct type
 
         # Convert input data to ValueTemplate
         input_template = self._convert_to_value_template(input_data)

--- a/sdks/python/src/stepflow_sdk/generated_flow.py
+++ b/sdks/python/src/stepflow_sdk/generated_flow.py
@@ -32,7 +32,7 @@ class Schema(Struct, kw_only=True):
 Component = Annotated[
     str,
     Meta(
-        description="Identifies a specific plugin and atomic functionality to execute."
+        description="Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf')."
     ),
 ]
 
@@ -42,49 +42,49 @@ class StepReference(Struct, kw_only=True):
 
 
 class WorkflowRef(Enum):
-    input = "input"
+    input = 'input'
 
 
 JsonPath = Annotated[
     str,
     Meta(
-        description="JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.",
-        examples=["field", "$.field", '$["field"]', "$[0]", "$.field[0].nested"],
+        description='JSON path expression to apply to the referenced value. May use `$` to reference the whole value. May also be a bare field name (without the leading $) if the referenced value is an object.',
+        examples=['field', '$.field', '$["field"]', '$[0]', '$.field[0].nested'],
     ),
 ]
 
 
 class OnSkipSkip(Struct, kw_only=True):
-    action: Literal["skip"]
+    action: Literal['skip']
 
 
 Value = Annotated[
     Any,
     Meta(
-        description="Any JSON value (object, array, string, number, boolean, or null)"
+        description='Any JSON value (object, array, string, number, boolean, or null)'
     ),
 ]
 
 
 class OnErrorFail(Struct, kw_only=True):
-    action: Literal["fail"]
+    action: Literal['fail']
 
 
 class OnErrorSkip(Struct, kw_only=True):
-    action: Literal["skip"]
+    action: Literal['skip']
 
 
 class OnErrorRetry(Struct, kw_only=True):
-    action: Literal["retry"]
+    action: Literal['retry']
 
 
 class Success(Struct, kw_only=True):
     result: Value
-    outcome: Literal["success"]
+    outcome: Literal['success']
 
 
 class Skipped(Struct, kw_only=True):
-    outcome: Literal["skipped"]
+    outcome: Literal['skipped']
 
 
 class FlowError(Struct, kw_only=True):
@@ -95,13 +95,13 @@ class FlowError(Struct, kw_only=True):
 
 class ExampleInput(Struct, kw_only=True):
     name: Annotated[
-        str, Meta(description="Name of the example input for display purposes.")
+        str, Meta(description='Name of the example input for display purposes.')
     ]
-    input: Annotated[Value, Meta(description="The input data for this example.")]
+    input: Annotated[Value, Meta(description='The input data for this example.')]
     description: (
         Annotated[
             str | None,
-            Meta(description="Optional description of what this example demonstrates."),
+            Meta(description='Optional description of what this example demonstrates.'),
         ]
         | None
     ) = None
@@ -111,9 +111,9 @@ class EscapedLiteral(Struct, kw_only=True):
     field_literal: Annotated[
         Value,
         Meta(
-            description="A literal value that should not be expanded for expressions.\nThis allows creating JSON values that contain `$from` without expansion."
+            description='A literal value that should not be expanded for expressions.\nThis allows creating JSON values that contain `$from` without expansion.'
         ),
-    ] = field(name="$literal")
+    ] = field(name='$literal')
 
 
 class WorkflowReference(Struct, kw_only=True):
@@ -123,13 +123,13 @@ class WorkflowReference(Struct, kw_only=True):
 BaseRef = Annotated[
     WorkflowReference | StepReference,
     Meta(
-        description="An expression that can be either a literal value or a template expression."
+        description='An expression that can be either a literal value or a template expression.'
     ),
 ]
 
 
 class OnSkipDefault(Struct, kw_only=True):
-    action: Literal["useDefault"]
+    action: Literal['useDefault']
     defaultValue: Value | None = None
 
 
@@ -138,23 +138,23 @@ SkipAction = OnSkipSkip | OnSkipDefault
 
 class Failed(Struct, kw_only=True):
     error: FlowError
-    outcome: Literal["failed"]
+    outcome: Literal['failed']
 
 
 FlowResult = Annotated[
-    Success | Skipped | Failed, Meta(description="The results of a step execution.")
+    Success | Skipped | Failed, Meta(description='The results of a step execution.')
 ]
 
 
 class Reference(Struct, kw_only=True):
-    field_from: Annotated[BaseRef, Meta(description="The source of the reference.")] = (
-        field(name="$from")
+    field_from: Annotated[BaseRef, Meta(description='The source of the reference.')] = (
+        field(name='$from')
     )
     path: (
         Annotated[
             JsonPath,
             Meta(
-                description="JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object."
+                description='JSON path expression to apply to the referenced value.\n\nDefaults to `$` (the whole referenced value).\nMay also be a bare field name (without the leading $) if\nthe referenced value is an object.'
             ),
         ]
         | None
@@ -165,48 +165,42 @@ class Reference(Struct, kw_only=True):
 Expr = Annotated[
     Reference | EscapedLiteral | Value,
     Meta(
-        description="An expression that can be either a literal value or a template expression."
+        description='An expression that can be either a literal value or a template expression.'
     ),
 ]
 
 
 ValueTemplate = Annotated[
-    Expr
-    | bool
-    | float
-    | str
-    | List["ValueTemplate"]
-    | Dict[str, "ValueTemplate"]
-    | None,
+    Expr | bool | float | str | List['ValueTemplate'] | Dict[str, 'ValueTemplate'] | None,
     Meta(
-        description="A value that can be either a literal JSON value or an expression that references other values using the $from syntax"
+        description='A value that can be either a literal JSON value or an expression that references other values using the $from syntax'
     ),
 ]
 
 
 class TestCase(Struct, kw_only=True):
-    name: Annotated[str, Meta(description="Unique identifier for the test case.")]
+    name: Annotated[str, Meta(description='Unique identifier for the test case.')]
     input: Annotated[
-        Value, Meta(description="Input data for the workflow in this test case.")
+        Value, Meta(description='Input data for the workflow in this test case.')
     ]
     description: (
         Annotated[
             str | None,
-            Meta(description="Optional description of what this test case verifies."),
+            Meta(description='Optional description of what this test case verifies.'),
         ]
         | None
     ) = None
     output: (
         Annotated[
             FlowResult | None,
-            Meta(description="Expected output from the workflow for this test case."),
+            Meta(description='Expected output from the workflow for this test case.'),
         ]
         | None
     ) = None
 
 
 class OnErrorDefault(Struct, kw_only=True):
-    action: Literal["useDefault"]
+    action: Literal['useDefault']
     defaultValue: ValueTemplate | None = None
 
 
@@ -215,33 +209,33 @@ ErrorAction = OnErrorFail | OnErrorSkip | OnErrorDefault | OnErrorRetry
 
 class TestConfig(Struct, kw_only=True):
     stepflowConfig: (
-        Annotated[Any, Meta(description="Stepflow configuration specific to tests.")]
+        Annotated[Any, Meta(description='Stepflow configuration specific to tests.')]
         | None
     ) = None
     cases: (
-        Annotated[List[TestCase], Meta(description="Test cases for the workflow.")]
+        Annotated[List[TestCase], Meta(description='Test cases for the workflow.')]
         | None
     ) = None
 
 
 class Step(Struct, kw_only=True):
-    id: Annotated[str, Meta(description="Identifier for the step")]
+    id: Annotated[str, Meta(description='Identifier for the step')]
     component: Annotated[
-        Component, Meta(description="The component to execute in this step")
+        Component, Meta(description='The component to execute in this step')
     ]
     inputSchema: (
-        Annotated[Schema | None, Meta(description="The input schema for this step.")]
+        Annotated[Schema | None, Meta(description='The input schema for this step.')]
         | None
     ) = None
     outputSchema: (
-        Annotated[Schema | None, Meta(description="The output schema for this step.")]
+        Annotated[Schema | None, Meta(description='The output schema for this step.')]
         | None
     ) = None
     skipIf: (
         Annotated[
             Expr | None,
             Meta(
-                description="If set and the referenced value is truthy, this step will be skipped."
+                description='If set and the referenced value is truthy, this step will be skipped.'
             ),
         ]
         | None
@@ -250,41 +244,41 @@ class Step(Struct, kw_only=True):
     input: (
         Annotated[
             ValueTemplate,
-            Meta(description="Arguments to pass to the component for this step"),
+            Meta(description='Arguments to pass to the component for this step'),
         ]
         | None
     ) = None
 
 
 class Flow(Struct, kw_only=True):
-    steps: Annotated[List[Step], Meta(description="The steps to execute for the flow.")]
-    name: Annotated[str | None, Meta(description="The name of the flow.")] | None = None
+    steps: Annotated[List[Step], Meta(description='The steps to execute for the flow.')]
+    name: Annotated[str | None, Meta(description='The name of the flow.')] | None = None
     description: (
-        Annotated[str | None, Meta(description="The description of the flow.")] | None
+        Annotated[str | None, Meta(description='The description of the flow.')] | None
     ) = None
     version: (
-        Annotated[str | None, Meta(description="The version of the flow.")] | None
+        Annotated[str | None, Meta(description='The version of the flow.')] | None
     ) = None
     inputSchema: (
-        Annotated[Schema | None, Meta(description="The input schema of the flow.")]
+        Annotated[Schema | None, Meta(description='The input schema of the flow.')]
         | None
     ) = None
     outputSchema: (
-        Annotated[Schema | None, Meta(description="The output schema of the flow.")]
+        Annotated[Schema | None, Meta(description='The output schema of the flow.')]
         | None
     ) = None
     output: (
         Annotated[
             ValueTemplate,
             Meta(
-                description="The outputs of the flow, mapping output names to their values."
+                description='The outputs of the flow, mapping output names to their values.'
             ),
         ]
         | None
     ) = None
     test: (
         Annotated[
-            TestConfig | None, Meta(description="Test configuration for the flow.")
+            TestConfig | None, Meta(description='Test configuration for the flow.')
         ]
         | None
     ) = None
@@ -292,7 +286,7 @@ class Flow(Struct, kw_only=True):
         Annotated[
             List[ExampleInput],
             Meta(
-                description="Example inputs for the workflow that can be used for testing and UI dropdowns."
+                description='Example inputs for the workflow that can be used for testing and UI dropdowns.'
             ),
         ]
         | None

--- a/sdks/python/src/stepflow_sdk/generated_protocol.py
+++ b/sdks/python/src/stepflow_sdk/generated_protocol.py
@@ -24,35 +24,34 @@ from typing import Annotated, Any, List, Literal
 
 from msgspec import Meta, Struct
 
-JsonRpc = (
-    Annotated[Literal["2.0"], Meta(description="The version of the JSON-RPC protocol.")]
-    | None
-)
+JsonRpc = Annotated[
+    Literal['2.0'], Meta(description='The version of the JSON-RPC protocol.')
+]
 
 
 RequestId = Annotated[
     str | int,
     Meta(
-        description="The identifier for a JSON-RPC request. Can be either a string or an integer.\nThe RequestId is used to match method responses to corresponding requests.\nIt should not be set on notifications."
+        description='The identifier for a JSON-RPC request. Can be either a string or an integer.\nThe RequestId is used to match method responses to corresponding requests.\nIt should not be set on notifications.'
     ),
 ]
 
 
 class Method(Enum):
-    initialize = "initialize"
-    initialized = "initialized"
-    components_list = "components/list"
-    components_info = "components/info"
-    components_execute = "components/execute"
-    blobs_put = "blobs/put"
-    blobs_get = "blobs/get"
+    initialize = 'initialize'
+    initialized = 'initialized'
+    components_list = 'components/list'
+    components_info = 'components/info'
+    components_execute = 'components/execute'
+    blobs_put = 'blobs/put'
+    blobs_get = 'blobs/get'
 
 
 class InitializeParams(Struct, kw_only=True):
     runtime_protocol_version: Annotated[
         int,
         Meta(
-            description="Maximum version of the protocol being used by the StepFlow runtime.",
+            description='Maximum version of the protocol being used by the StepFlow runtime.',
             ge=0,
         ),
     ]
@@ -67,7 +66,7 @@ class InitializeParams(Struct, kw_only=True):
 Component = Annotated[
     str,
     Meta(
-        description="Identifies a specific plugin and atomic functionality to execute."
+        description="Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf')."
     ),
 ]
 
@@ -75,14 +74,14 @@ Component = Annotated[
 Value = Annotated[
     Any,
     Meta(
-        description="Any JSON value (object, array, string, number, boolean, or null)"
+        description='Any JSON value (object, array, string, number, boolean, or null)'
     ),
 ]
 
 
 class ComponentInfoParams(Struct, kw_only=True):
     component: Annotated[
-        Component, Meta(description="The component to get information about.")
+        Component, Meta(description='The component to get information about.')
     ]
 
 
@@ -93,7 +92,7 @@ class ComponentListParams(Struct, kw_only=True):
 BlobId = Annotated[
     str,
     Meta(
-        description="A SHA-256 hash of the blob content, represented as a hexadecimal string."
+        description='A SHA-256 hash of the blob content, represented as a hexadecimal string.'
     ),
 ]
 
@@ -106,14 +105,14 @@ class InitializeResult(Struct, kw_only=True):
     server_protocol_version: Annotated[
         int,
         Meta(
-            description="Version of the protocol being used by the component server.",
+            description='Version of the protocol being used by the component server.',
             ge=0,
         ),
     ]
 
 
 class ComponentExecuteResult(Struct, kw_only=True):
-    output: Annotated[Value, Meta(description="The result of the component execution.")]
+    output: Annotated[Value, Meta(description='The result of the component execution.')]
 
 
 class Schema(Struct, kw_only=True):
@@ -129,15 +128,15 @@ class PutBlobResult(Struct, kw_only=True):
 
 
 class Error(Struct, kw_only=True):
-    code: Annotated[int, Meta(description="A numeric code indicating the error type.")]
+    code: Annotated[int, Meta(description='A numeric code indicating the error type.')]
     message: Annotated[
-        str, Meta(description="Concise, single-sentence description of the error.")
+        str, Meta(description='Concise, single-sentence description of the error.')
     ]
     data: (
         Annotated[
             Value | None,
             Meta(
-                description="Primitive or structured value that contains additional information about the error."
+                description='Primitive or structured value that contains additional information about the error.'
             ),
         ]
         | None
@@ -149,19 +148,19 @@ class Initialized(Struct, kw_only=True):
 
 
 class ComponentExecuteParams(Struct, kw_only=True):
-    component: Annotated[Component, Meta(description="The component to execute.")]
-    input: Annotated[Value, Meta(description="The input to the component.")]
+    component: Annotated[Component, Meta(description='The component to execute.')]
+    input: Annotated[Value, Meta(description='The input to the component.')]
 
 
 class GetBlobParams(Struct, kw_only=True):
-    blob_id: Annotated[BlobId, Meta(description="The ID of the blob to retrieve.")]
+    blob_id: Annotated[BlobId, Meta(description='The ID of the blob to retrieve.')]
 
 
 class ComponentInfo(Struct, kw_only=True):
-    component: Annotated[Component, Meta(description="The component ID.")]
+    component: Annotated[Component, Meta(description='The component ID.')]
     description: (
         Annotated[
-            str | None, Meta(description="Optional description of the component.")
+            str | None, Meta(description='Optional description of the component.')
         ]
         | None
     ) = None
@@ -169,7 +168,7 @@ class ComponentInfo(Struct, kw_only=True):
         Annotated[
             Schema | None,
             Meta(
-                description="The input schema for the component.\n\nCan be any valid JSON schema (object, primitive, array, etc.)."
+                description='The input schema for the component.\n\nCan be any valid JSON schema (object, primitive, array, etc.).'
             ),
         ]
         | None
@@ -178,7 +177,7 @@ class ComponentInfo(Struct, kw_only=True):
         Annotated[
             Schema | None,
             Meta(
-                description="The output schema for the component.\n\nCan be any valid JSON schema (object, primitive, array, etc.)."
+                description='The output schema for the component.\n\nCan be any valid JSON schema (object, primitive, array, etc.).'
             ),
         ]
         | None
@@ -187,33 +186,33 @@ class ComponentInfo(Struct, kw_only=True):
 
 class ListComponentsResult(Struct, kw_only=True):
     components: Annotated[
-        List[ComponentInfo], Meta(description="A list of all available components.")
+        List[ComponentInfo], Meta(description='A list of all available components.')
     ]
 
 
 class MethodError(Struct, kw_only=True):
     id: RequestId
     error: Annotated[
-        Error, Meta(description="An error that occurred during method execution.")
+        Error, Meta(description='An error that occurred during method execution.')
     ]
-    jsonrpc: JsonRpc | None = "2.0"
+    jsonrpc: JsonRpc | None = '2.0'
 
 
 class Notification(Struct, kw_only=True):
-    method: Annotated[Method, Meta(description="The notification method being called.")]
+    method: Annotated[Method, Meta(description='The notification method being called.')]
     params: Annotated[
         Initialized,
         Meta(
-            description="The parameters for the notification.",
-            title="NotificationParams",
+            description='The parameters for the notification.',
+            title='NotificationParams',
         ),
     ]
-    jsonrpc: JsonRpc | None = "2.0"
+    jsonrpc: JsonRpc | None = '2.0'
 
 
 class MethodRequest(Struct, kw_only=True):
     id: RequestId
-    method: Annotated[Method, Meta(description="The method being called.")]
+    method: Annotated[Method, Meta(description='The method being called.')]
     params: Annotated[
         InitializeParams
         | ComponentExecuteParams
@@ -222,15 +221,15 @@ class MethodRequest(Struct, kw_only=True):
         | GetBlobParams
         | PutBlobParams,
         Meta(
-            description="The parameters for the method call. Set on method requests.",
-            title="MethodParams",
+            description='The parameters for the method call. Set on method requests.',
+            title='MethodParams',
         ),
     ]
-    jsonrpc: JsonRpc | None = "2.0"
+    jsonrpc: JsonRpc | None = '2.0'
 
 
 class ComponentInfoResult(Struct, kw_only=True):
-    info: Annotated[ComponentInfo, Meta(description="Information about the component.")]
+    info: Annotated[ComponentInfo, Meta(description='Information about the component.')]
 
 
 class MethodSuccess(Struct, kw_only=True):
@@ -243,22 +242,22 @@ class MethodSuccess(Struct, kw_only=True):
         | GetBlobResult
         | PutBlobResult,
         Meta(
-            description="The result of a successful method execution.",
-            title="MethodResult",
+            description='The result of a successful method execution.',
+            title='MethodResult',
         ),
     ]
-    jsonrpc: JsonRpc | None = "2.0"
+    jsonrpc: JsonRpc | None = '2.0'
 
 
 Message = Annotated[
     MethodRequest | MethodSuccess | MethodError | Notification,
     Meta(
-        description="The messages supported by the StepFlow protocol. These correspond to JSON-RPC 2.0 messages.\n\nNote that this defines a superset containing both client-sent and server-sent messages.",
-        title="Message",
+        description='The messages supported by the StepFlow protocol. These correspond to JSON-RPC 2.0 messages.\n\nNote that this defines a superset containing both client-sent and server-sent messages.',
+        title='Message',
     ),
 ]
 
 
 MethodResponse = Annotated[
-    MethodSuccess | MethodError, Meta(description="Response to a method request.")
+    MethodSuccess | MethodError, Meta(description='Response to a method request.')
 ]

--- a/sdks/python/src/stepflow_sdk/server.py
+++ b/sdks/python/src/stepflow_sdk/server.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
 from typing import Any, assert_never
-from urllib.parse import urlparse
+# No longer needed: from urllib.parse import urlparse
 
 import msgspec
 
@@ -165,13 +165,13 @@ class StepflowStdioServer:
             return decorator
         return decorator(func)
 
-    def get_component(self, component_url: str) -> ComponentEntry | None:
-        """Get a registered component by name."""
-        parse_result = urlparse(component_url)
-        component_name = parse_result.netloc
-        if parse_result.path:
-            component_name += "/" + parse_result.path
-        return self._components.get(component_name)
+    def get_component(self, component_path: str) -> ComponentEntry | None:
+        """Get a registered component by path."""
+        # Handle path format: /plugin/component_name
+        if component_path.startswith(f"/{self._protocol_prefix}/"):
+            component_name = component_path[len(f"/{self._protocol_prefix}/"):]
+            return self._components.get(component_name)
+        return None
 
     async def _handle_method_request(self, request: MethodRequest) -> MethodResponse:
         """Handle a method request and return a response."""
@@ -257,7 +257,7 @@ class StepflowStdioServer:
                 # Return component info objects
                 component_infos = []
                 for name, component in self._components.items():
-                    component_url = f"{self._protocol_prefix}://{name}"
+                    component_url = f"/{self._protocol_prefix}/{name}"
                     component_infos.append(
                         ComponentInfo(
                             component=component_url,

--- a/sdks/python/tests/test_flow_builder.py
+++ b/sdks/python/tests/test_flow_builder.py
@@ -35,14 +35,14 @@ def test_basic_flow_builder():
     # Add a step that uses workflow input
     step1 = builder.add_step(
         id="add_numbers",
-        component="builtin/eval",
+        component="eval",
         input_data={"expr": "x + y", "x": Value.input().x, "y": Value.input().y},
     )
 
     # Add a step that uses the output of the previous step
     step2 = builder.add_step(
         id="double_result",
-        component="builtin/eval",
+        component="eval",
         input_data={"expr": "result * 2", "result": Value.step(step1.id, "$")},
     )
 
@@ -60,12 +60,12 @@ def test_basic_flow_builder():
     # Check step 1
     step1_def = flow.steps[0]
     assert step1_def.id == "add_numbers"
-    assert step1_def.component == "builtin/eval"
+    assert step1_def.component == "eval"
 
     # Check step 2
     step2_def = flow.steps[1]
     assert step2_def.id == "double_result"
-    assert step2_def.component == "builtin/eval"
+    assert step2_def.component == "eval"
 
 
 def test_step_references():
@@ -74,7 +74,7 @@ def test_step_references():
 
     # Add a step
     step1 = builder.add_step(
-        id="test_step", component="test/component", input_data={"value": 42}
+        id="test_step", component="/test/component", input_data={"value": 42}
     )
 
     # Test different ways to reference the step
@@ -86,15 +86,15 @@ def test_step_references():
     # Add steps that use these references
     builder.add_step(
         id="step1",
-        component="test/component",
+        component="/test/component",
         input_data={"direct": Value.step(step1.id, "$")},
     )
-    builder.add_step(id="step2", component="test/component", input_data={"field": ref2})
+    builder.add_step(id="step2", component="/test/component", input_data={"field": ref2})
     builder.add_step(
-        id="step3", component="test/component", input_data={"indexed": ref3}
+        id="step3", component="/test/component", input_data={"indexed": ref3}
     )
     builder.add_step(
-        id="step4", component="test/component", input_data={"nested": ref4}
+        id="step4", component="/test/component", input_data={"nested": ref4}
     )
 
     # Set output to make the test complete
@@ -116,16 +116,16 @@ def test_workflow_input_references():
 
     # Add steps that use these references
     builder.add_step(
-        id="step1", component="test/component", input_data={"full_input": input_ref}
+        id="step1", component="/test/component", input_data={"full_input": input_ref}
     )
     builder.add_step(
-        id="step2", component="test/component", input_data={"field": field_ref}
+        id="step2", component="/test/component", input_data={"field": field_ref}
     )
     builder.add_step(
-        id="step3", component="test/component", input_data={"indexed": indexed_ref}
+        id="step3", component="/test/component", input_data={"indexed": indexed_ref}
     )
     builder.add_step(
-        id="step4", component="test/component", input_data={"nested": nested_ref}
+        id="step4", component="/test/component", input_data={"nested": nested_ref}
     )
 
     # Set output to make the test complete
@@ -142,7 +142,7 @@ def test_literal_values():
     # Add a step with a literal value that contains $from
     builder.add_step(
         id="literal_step",
-        component="test/component",
+        component="/test/component",
         input_data={
             "literal_with_from": Value.literal(
                 {"$from": "this should not be expanded"}
@@ -165,19 +165,19 @@ def test_error_handling():
     # Add steps with different error handling
     builder.add_step(
         id="fail_step",
-        component="test/component",
+        component="/test/component",
         input_data={"value": 1},
         on_error=OnErrorFail(action="fail"),
     )
     builder.add_step(
         id="skip_step",
-        component="test/component",
+        component="/test/component",
         input_data={"value": 2},
         on_error=OnErrorSkip(action="skip"),
     )
     builder.add_step(
         id="retry_step",
-        component="test/component",
+        component="/test/component",
         input_data={"value": 3},
         on_error=OnErrorRetry(action="retry"),
     )
@@ -209,7 +209,7 @@ def test_error_default_handling():
     # Add step with OnErrorDefault
     builder.add_step(
         id="default_step",
-        component="test/component",
+        component="/test/component",
         input_data={"value": 1},
         on_error=OnErrorDefault(action="useDefault", defaultValue="fallback_value"),
     )
@@ -233,7 +233,7 @@ def test_build_requires_output():
 
     # Add a step but don't set output
     builder.add_step(
-        id="test_step", component="test/component", input_data={"value": 1}
+        id="test_step", component="/test/component", input_data={"value": 1}
     )
 
     # build() should fail without output
@@ -252,13 +252,13 @@ def test_step_ids():
 
     # Add steps with explicit IDs
     step1 = builder.add_step(
-        id="custom_step_1", component="test/component", input_data={"value": 1}
+        id="custom_step_1", component="/test/component", input_data={"value": 1}
     )
     step2 = builder.add_step(
-        id="custom_step_2", component="test/component", input_data={"value": 2}
+        id="custom_step_2", component="/test/component", input_data={"value": 2}
     )
     step3 = builder.add_step(
-        id="custom_step_3", component="test/component", input_data={"value": 3}
+        id="custom_step_3", component="/test/component", input_data={"value": 3}
     )
 
     # Set output to make the test complete
@@ -285,14 +285,14 @@ def test_complex_nested_references():
     # Add a step
     step1 = builder.add_step(
         id="nested_step_1",
-        component="test/component",
+        component="/test/component",
         input_data={"data": Value.input().config.settings},
     )
 
     # Add another step that references nested data from the first step
     step2 = builder.add_step(
         id="nested_step_2",
-        component="test/component",
+        component="/test/component",
         input_data={
             "prev_result": step1.output.nested.value,
             "input_ref": Value.input().another.nested.field,
@@ -313,13 +313,13 @@ def test_get_references():
     # Add a step that uses workflow input
     step1 = builder.add_step(
         id="input_step",
-        component="test/component",
+        component="/test/component",
         input_data={"x": Value.input().x, "y": Value.input().nested.y},
     )
 
     # Add a step that references the first step
     step2 = builder.add_step(
-        id="ref_step", component="test/component", input_data={"result": step1.output}
+        id="ref_step", component="/test/component", input_data={"result": step1.output}
     )
 
     # Set flow output that references step2
@@ -354,7 +354,7 @@ def test_get_step_references():
     # Add a step with multiple references
     step1 = builder.add_step(
         id="test_step",
-        component="test/component",
+        component="/test/component",
         input_data={
             "input_val": Value.input().value,
             "nested_input": Value.input().config.setting,
@@ -383,7 +383,7 @@ def test_get_references_with_skip_condition():
     # Add a step with a skipIf condition
     step1 = builder.add_step(
         id="skip_test",
-        component="test/component",
+        component="/test/component",
         input_data={"value": 42},
         skip_if=Value.input().skip_flag,
     )
@@ -407,7 +407,7 @@ def test_get_references_with_literal_values():
     # Add a step with literal values
     step1 = builder.add_step(
         id="literal_test",
-        component="test/component",
+        component="/test/component",
         input_data={
             "literal_dict": Value.literal({"$from": "should not be a reference"}),
             "normal_value": "just a string",
@@ -432,7 +432,7 @@ def test_get_references_mixed_types():
     # Add a step with mixed reference types
     step1 = builder.add_step(
         id="mixed_test",
-        component="test/component",
+        component="/test/component",
         input_data={
             "input_ref": Value.input().value,
             "literal_value": "string",
@@ -465,7 +465,7 @@ def test_flowbuilder_load():
 
     step1 = original_builder.add_step(
         id="custom_step",
-        component="test/component",
+        component="/test/component",
         input_data={"input": Value.input().field, "literal": Value.literal("constant")},
     )
 

--- a/sdks/python/tests/test_server.py
+++ b/sdks/python/tests/test_server.py
@@ -72,7 +72,7 @@ def test_component_registration(server):
         )
 
     assert "test_component" in server._components
-    component = server.get_component("python://test_component")
+    component = server.get_component("/python/test_component")
     assert isinstance(component, ComponentEntry)
     assert component.name == "test_component"
     assert component.input_type == ValidInput
@@ -87,7 +87,7 @@ def test_component_with_custom_name(server):
         )
 
     assert "custom_name" in server._components
-    component = server.get_component("python://custom_name")
+    component = server.get_component("/python/custom_name")
     assert isinstance(component, ComponentEntry)
     assert component.name == "custom_name"
     assert component.input_type == ValidInput
@@ -101,7 +101,7 @@ def test_component_execution(server):
             greeting=f"Hello {input_data.name}!", age_next_year=input_data.age + 1
         )
 
-    component = server.get_component("python://test_component")
+    component = server.get_component("/python/test_component")
     assert component is not None
     result = component.function(ValidInput(name="Alice", age=25))
     assert isinstance(result, ValidOutput)
@@ -166,7 +166,7 @@ async def test_handle_component_info(server):
     request = MethodRequest(
         id=str(UUID(int=1)),
         method=Method.components_info,
-        params=ComponentInfoParams(component="python://test_component"),
+        params=ComponentInfoParams(component="/python/test_component"),
     )
     response = await server._handle_message(request)
     assert response.id == request.id
@@ -184,7 +184,7 @@ async def test_handle_component_info_not_found(server):
     request = MethodRequest(
         id=str(UUID(int=1)),
         method=Method.components_info,
-        params=ComponentInfoParams(component="python://non_existent"),
+        params=ComponentInfoParams(component="/python/non_existent"),
     )
     with pytest.raises(ComponentNotFoundError):
         await server._handle_message(request)
@@ -204,7 +204,7 @@ async def test_handle_component_execute(server):
         id=str(UUID(int=1)),
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="python://test_component", input={"name": "Alice", "age": 25}
+            component="/python/test_component", input={"name": "Alice", "age": 25}
         ),
     )
     response = await server._handle_message(request)
@@ -226,7 +226,7 @@ async def test_handle_component_execute_invalid_input(server):
         id=str(UUID(int=1)),
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="python://test_component", input={"invalid": "input"}
+            component="/python/test_component", input={"invalid": "input"}
         ),
     )
 
@@ -254,8 +254,8 @@ async def test_handle_list_components(server):
     assert response.id == request.id
     assert len(response.result.components) == 2
     component_urls = [comp.component for comp in response.result.components]
-    assert "python://component1" in component_urls
-    assert "python://component2" in component_urls
+    assert "/python/component1" in component_urls
+    assert "/python/component2" in component_urls
 
 
 @pytest.mark.asyncio
@@ -299,7 +299,7 @@ async def test_server_responses_include_jsonrpc(server):
         id="jsonrpc-test",
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="python://test_component", input={"name": "Test", "age": 30}
+            component="/python/test_component", input={"name": "Test", "age": 30}
         ),
     )
 

--- a/stepflow-rs/crates/stepflow-analysis/src/dependency.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/dependency.rs
@@ -201,7 +201,7 @@ mod tests {
     fn create_test_step(id: &str, input: serde_json::Value) -> Step {
         Step {
             id: id.to_string(),
-            component: Component::from_string("mock://test"),
+            component: Component::from_string("/mock/test"),
             input: ValueTemplate::parse_value(input).unwrap(),
             input_schema: None,
             output_schema: None,
@@ -220,7 +220,7 @@ mod tests {
             steps: vec![
                 Step {
                     id: "step1".to_string(),
-                    component: Component::from_string("mock://test"),
+                    component: Component::from_string("/mock/test"),
                     input: ValueTemplate::workflow_input(JsonPath::default()),
                     input_schema: None,
                     output_schema: None,
@@ -229,7 +229,7 @@ mod tests {
                 },
                 Step {
                     id: "step2".to_string(),
-                    component: Component::from_string("mock://test"),
+                    component: Component::from_string("/mock/test"),
                     input: ValueTemplate::step_ref("step1", JsonPath::default()),
                     input_schema: None,
                     output_schema: None,

--- a/stepflow-rs/crates/stepflow-analysis/src/validation.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/validation.rs
@@ -277,16 +277,16 @@ fn validate_component(component: &Component, path: &[String], diagnostics: &mut 
         }
     } else {
         // For non-builtin components, check basic format
-        let url_str = component.url_string();
-        if !url_str.contains("://") {
-            let error = "Component URL must contain '://' for non-builtin components".to_string();
+        let path_str = component.path_string();
+        if !path_str.starts_with('/') {
+            let error = "Component path must start with '/' for non-builtin components".to_string();
 
             // Extract step_id from path for backwards compatibility with DiagnosticMessage
             let step_id = path.get(1).unwrap_or(&"unknown".to_string()).clone();
             diagnostics.add(
                 DiagnosticMessage::InvalidComponentUrl {
                     step_id,
-                    url: url_str.to_string(),
+                    url: path_str.to_string(),
                     error,
                 },
                 path.to_vec(),
@@ -378,7 +378,7 @@ mod tests {
     fn create_test_step(id: &str, input: serde_json::Value) -> Step {
         Step {
             id: id.to_string(),
-            component: Component::from_string("mock://test"),
+            component: Component::from_string("/mock/test"),
             input: serde_json::from_value(input).unwrap(),
             input_schema: None,
             output_schema: None,

--- a/stepflow-rs/crates/stepflow-components-mcp/src/schema.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/src/schema.rs
@@ -45,10 +45,10 @@ pub fn mcp_tool_to_component_info(tool: &Tool) -> Result<ComponentInfo> {
             .attach_printable("Failed to create output schema")
     })?;
 
-    // Create component URL in MCP-compliant format: mcp://server_name/tool_name
+    // Create component path in MCP-compliant format: /mcp/server/tool_name
     // Note: The actual server name will be injected by the plugin when listing components
-    let component_url = format!("mcp://server/{}", tool.name);
-    let component = Component::from_string(&component_url);
+    let component_path = format!("/mcp/server/{}", tool.name);
+    let component = Component::from_string(&component_path);
 
     Ok(ComponentInfo {
         component,
@@ -58,11 +58,14 @@ pub fn mcp_tool_to_component_info(tool: &Tool) -> Result<ComponentInfo> {
     })
 }
 
-/// Convert StepFlow Component URL to MCP tool name
-pub fn component_url_to_tool_name(component_url: &str) -> Option<String> {
-    // Expected format: plugin_name://tool_name
-    if let Some(start) = component_url.find("://") {
-        return Some(component_url[start + 3..].to_string());
+/// Convert StepFlow Component path to MCP tool name
+pub fn component_path_to_tool_name(component_path: &str) -> Option<String> {
+    // Expected format: /plugin_name/tool_name
+    if component_path.starts_with('/') {
+        let without_leading_slash = &component_path[1..];
+        if let Some(pos) = without_leading_slash.find('/') {
+            return Some(without_leading_slash[pos + 1..].to_string());
+        }
     }
     None
 }
@@ -72,17 +75,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_component_url_to_tool_name() {
+    fn test_component_path_to_tool_name() {
         assert_eq!(
-            component_url_to_tool_name("filesystem://read_file"),
+            component_path_to_tool_name("/filesystem/read_file"),
             Some("read_file".to_string())
         );
 
         assert_eq!(
-            component_url_to_tool_name("mock-server://tool_name"),
+            component_path_to_tool_name("/mock-server/tool_name"),
             Some("tool_name".to_string())
         );
 
-        assert_eq!(component_url_to_tool_name("invalidurl"), None);
+        assert_eq!(component_path_to_tool_name("invalidpath"), None);
+        assert_eq!(component_path_to_tool_name("/filesystem"), None);
     }
 }

--- a/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
@@ -86,13 +86,13 @@ async fn test_mcp_plugin_initialization() {
     let components = plugin.list_components().await.unwrap();
     assert_eq!(components.len(), 2);
 
-    // Check that the component URLs are correct
-    let urls: Vec<String> = components
+    // Check that the component paths are correct
+    let paths: Vec<String> = components
         .iter()
-        .map(|c| c.component.url_string().to_string())
+        .map(|c| c.component.path_string().to_string())
         .collect();
-    assert!(urls.contains(&"mock-server://echo".to_string()));
-    assert!(urls.contains(&"mock-server://add".to_string()));
+    assert!(paths.contains(&"/mock-server/echo".to_string()));
+    assert!(paths.contains(&"/mock-server/add".to_string()));
 }
 
 #[tokio::test]
@@ -113,7 +113,7 @@ async fn test_mcp_tool_execution() {
     plugin.init(&test_context).await.unwrap();
 
     // Test echo tool
-    let echo_component = Component::from_string("mock-server://echo");
+    let echo_component = Component::from_string("/mock-server/echo");
     let echo_input = ValueRef::new(json!({
         "message": "Hello, MCP!"
     }));
@@ -136,7 +136,7 @@ async fn test_mcp_tool_execution() {
     }
 
     // Test add tool
-    let add_component = Component::from_string("mock-server://add");
+    let add_component = Component::from_string("/mock-server/add");
     let add_input = ValueRef::new(json!({
         "a": 5,
         "b": 3
@@ -178,7 +178,7 @@ async fn test_mcp_error_handling() {
     plugin.init(&test_context).await.unwrap();
 
     // Test calling a non-existent tool
-    let bad_component = Component::from_string("mock-server://nonexistent");
+    let bad_component = Component::from_string("/mock-server/nonexistent");
     let input = ValueRef::new(json!({}));
 
     let result = plugin.execute(&bad_component, exec_context, input).await;

--- a/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
+++ b/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
@@ -348,7 +348,7 @@ mod tests {
             output_schema: None,
             steps: vec![Step {
                 id: "step1".to_string(),
-                component: Component::from_string("mock://test"),
+                component: Component::from_string("/mock/test"),
                 input: ValueTemplate::literal(json!({})),
                 input_schema: None,
                 output_schema: None,

--- a/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
@@ -357,11 +357,11 @@ mod tests {
                 count:
                     type: integer
         steps:
-          - component: langflow://echo
+          - component: /langflow/echo
             id: s1
             input:
               a: "hello world"
-          - component: mcp+http://foo/bar
+          - component: /mcp/foo/bar
             id: s2
             input:
               a: "hello world 2"
@@ -392,9 +392,9 @@ mod tests {
 
         // Verify step details
         assert_eq!(flow.steps[0].id, "s1");
-        assert_eq!(flow.steps[0].component.url_string(), "langflow://echo");
+        assert_eq!(flow.steps[0].component.path_string(), "/langflow/echo");
         assert_eq!(flow.steps[1].id, "s2");
-        assert_eq!(flow.steps[1].component.url_string(), "mcp+http://foo/bar");
+        assert_eq!(flow.steps[1].component.path_string(), "/mcp/foo/bar");
 
         // Test round-trip serialization to ensure expressions are preserved
         let serialized = serde_json::to_string(&flow).unwrap();
@@ -417,7 +417,7 @@ mod tests {
             steps: vec![
                 Step {
                     id: "s1".to_owned(),
-                    component: Component::from_string("langflow://echo"),
+                    component: Component::from_string("/langflow/echo"),
                     input: ValueTemplate::literal(serde_json::json!({
                         "a": "hello world"
                     })),
@@ -428,7 +428,7 @@ mod tests {
                 },
                 Step {
                     id: "s2".to_owned(),
-                    component: Component::from_string("mcp+http://foo/bar"),
+                    component: Component::from_string("/mcp/foo/bar"),
                     input: ValueTemplate::literal(serde_json::json!({
                         "a": "hello world 2"
                     })),

--- a/stepflow-rs/crates/stepflow-core/src/workflow/step.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/step.rs
@@ -143,7 +143,7 @@ mod tests {
     fn test_step_serialization_with_error_action() {
         let step = Step {
             id: "test_step".to_string(),
-            component: Component::from_string("mock://test_component"),
+            component: Component::from_string("/mock/test_component"),
             input_schema: None,
             output_schema: None,
             skip_if: None,
@@ -163,7 +163,7 @@ mod tests {
     fn test_step_default_error_action_not_serialized() {
         let step = Step {
             id: "test_step".to_string(),
-            component: Component::from_string("mock://test_component"),
+            component: Component::from_string("/mock/test_component"),
             input_schema: None,
             output_schema: None,
             skip_if: None,

--- a/stepflow-rs/crates/stepflow-execution/src/workflow_executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/workflow_executor.rs
@@ -1071,7 +1071,7 @@ mod tests {
     fn create_test_step(id: &str, input: serde_json::Value) -> Step {
         Step {
             id: id.to_string(),
-            component: Component::from_string("mock://test"),
+            component: Component::from_string("/mock/test"),
             input_schema: None,
             output_schema: None,
             skip_if: None,
@@ -1129,7 +1129,7 @@ mod tests {
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://simple
+    component: /mock/simple
     input:
       $from:
         workflow: input
@@ -1140,7 +1140,7 @@ output:
 
         let input_value = json!({"message": "hello"});
         let mock_behaviors = vec![(
-            "mock://simple",
+            "/mock/simple",
             FlowResult::Success {
                 result: ValueRef::new(json!({"output": "processed"})),
             },
@@ -1163,12 +1163,12 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://first
+    component: /mock/first
     input:
       $from:
         workflow: input
   - id: step2
-    component: mock://second
+    component: /mock/second
     input:
       $from:
         step: step1
@@ -1182,13 +1182,13 @@ output:
 
         let mock_behaviors = vec![
             (
-                "mock://first",
+                "/mock/first",
                 FlowResult::Success {
                     result: ValueRef::new(step1_output.clone()),
                 },
             ),
             (
-                "mock://second",
+                "/mock/second",
                 FlowResult::Success {
                     result: ValueRef::new(json!({"final": 30})),
                 },
@@ -1213,12 +1213,12 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://first
+    component: /mock/first
     input:
       $from:
         workflow: input
   - id: step2
-    component: mock://second
+    component: /mock/second
     input:
       $from:
         step: step1
@@ -1230,13 +1230,13 @@ output:
         let workflow_input = json!({"value": 10});
         let mock_behaviors = vec![
             (
-                "mock://first",
+                "/mock/first",
                 FlowResult::Success {
                     result: ValueRef::new(json!({"result": 20})),
                 },
             ),
             (
-                "mock://second",
+                "/mock/second",
                 FlowResult::Success {
                     result: ValueRef::new(json!({"final": 30})),
                 },
@@ -1298,11 +1298,11 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://identity
+    component: /mock/identity
     input:
       value: "step1_output"
   - id: step2
-    component: mock://identity
+    component: /mock/identity
     input:
       value: { $from: { step: step1 } }
 output:
@@ -1390,15 +1390,15 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://identity
+    component: /mock/identity
     input:
       value: "step1_result"
   - id: step2
-    component: mock://identity
+    component: /mock/identity
     input:
       value: { $from: { step: step1 } }
   - id: step3
-    component: mock://identity
+    component: /mock/identity
     input:
       value: { $from: { step: step2 } }
 output:
@@ -1479,23 +1479,23 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://identity
+    component: /mock/identity
     input:
       value: "step1_result"
   - id: step2
-    component: mock://identity
+    component: /mock/identity
     input:
       value: "step2_result"
   - id: step3
-    component: mock://identity
+    component: /mock/identity
     input:
       value: { $from: { step: step1 } }
   - id: step4
-    component: mock://identity
+    component: /mock/identity
     input:
       value: { $from: { step: step2 } }
   - id: step5
-    component: mock://identity
+    component: /mock/identity
     input:
       deps: [{ $from: { step: step3 } }, { $from: { step: step4 } }]
 output:
@@ -1578,7 +1578,7 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://identity
+    component: /mock/identity
     input:
       value: "step1_result"
 output:
@@ -1619,17 +1619,17 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: step1
-    component: mock://parallel1
+    component: /mock/parallel1
     input:
       $from:
         workflow: input
   - id: step2
-    component: mock://parallel2
+    component: /mock/parallel2
     input:
       $from:
         workflow: input
   - id: final
-    component: mock://combiner
+    component: /mock/combiner
     input:
       step1:
         $from:
@@ -1650,19 +1650,19 @@ output:
         // Test parallel execution
         let parallel_mock_behaviors = vec![
             (
-                "mock://parallel1",
+                "/mock/parallel1",
                 FlowResult::Success {
                     result: ValueRef::new(step1_output.clone()),
                 },
             ),
             (
-                "mock://parallel2",
+                "/mock/parallel2",
                 FlowResult::Success {
                     result: ValueRef::new(step2_output.clone()),
                 },
             ),
             (
-                "mock://combiner",
+                "/mock/combiner",
                 FlowResult::Success {
                     result: ValueRef::new(final_output.clone()),
                 },
@@ -1680,19 +1680,19 @@ output:
         // Test sequential execution
         let sequential_mock_behaviors = vec![
             (
-                "mock://parallel1",
+                "/mock/parallel1",
                 FlowResult::Success {
                     result: ValueRef::new(step1_output.clone()),
                 },
             ),
             (
-                "mock://parallel2",
+                "/mock/parallel2",
                 FlowResult::Success {
                     result: ValueRef::new(step2_output.clone()),
                 },
             ),
             (
-                "mock://combiner",
+                "/mock/combiner",
                 FlowResult::Success {
                     result: ValueRef::new(final_output.clone()),
                 },
@@ -1734,7 +1734,7 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: failing_step
-    component: mock://error
+    component: /mock/error
     onError:
       action: skip
     input:
@@ -1745,7 +1745,7 @@ output:
 "#;
 
         let mock_behaviors = vec![(
-            "mock://error",
+            "/mock/error",
             FlowResult::Failed {
                 error: stepflow_core::FlowError::new(500, "Test error"),
             },
@@ -1769,7 +1769,7 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: failing_step
-    component: mock://error
+    component: /mock/error
     onError:
       action: useDefault
       defaultValue: {"fallback": "value"}
@@ -1781,7 +1781,7 @@ output:
 "#;
 
         let mock_behaviors = vec![(
-            "mock://error",
+            "/mock/error",
             FlowResult::Failed {
                 error: stepflow_core::FlowError::new(500, "Test error"),
             },
@@ -1804,7 +1804,7 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: failing_step
-    component: mock://error
+    component: /mock/error
     onError:
       action: useDefault
     input:
@@ -1815,7 +1815,7 @@ output:
 "#;
 
         let mock_behaviors = vec![(
-            "mock://error",
+            "/mock/error",
             FlowResult::Failed {
                 error: stepflow_core::FlowError::new(500, "Test error"),
             },
@@ -1838,7 +1838,7 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: failing_step
-    component: mock://error
+    component: /mock/error
     onError:
       action: fail
     input:
@@ -1849,7 +1849,7 @@ output:
 "#;
 
         let mock_behaviors = vec![(
-            "mock://error",
+            "/mock/error",
             FlowResult::Failed {
                 error: stepflow_core::FlowError::new(500, "Test error"),
             },
@@ -1873,7 +1873,7 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: success_step
-    component: mock://success
+    component: /mock/success
     onError:
       action: skip
     input: {}
@@ -1883,7 +1883,7 @@ output:
 "#;
 
         let mock_behaviors = vec![(
-            "mock://success",
+            "/mock/success",
             FlowResult::Success {
                 result: ValueRef::new(json!({"result": "success"})),
             },
@@ -1907,13 +1907,13 @@ output:
         let workflow_yaml = r#"
 steps:
   - id: failing_step
-    component: mock://error
+    component: /mock/error
     onError:
       action: skip
     input:
       mode: error
   - id: downstream_step
-    component: mock://success
+    component: /mock/success
     input:
       $from:
         step: failing_step
@@ -1924,13 +1924,13 @@ output:
 
         let mock_behaviors = vec![
             (
-                "mock://error",
+                "/mock/error",
                 FlowResult::Failed {
                     error: stepflow_core::FlowError::new(500, "Test error"),
                 },
             ),
             (
-                "mock://success",
+                "/mock/success",
                 FlowResult::Success {
                     result: ValueRef::new(json!({"handled_skip": true})),
                 },

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_custom_config.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_custom_config.snap
@@ -7,7 +7,7 @@ info:
     - "--omit-stack-trace"
     - "--log-level=error"
     - list-components
-    - "--config=/var/folders/c4/dcr0mh3d183d5kh9gf89wsc00000gn/T/.tmpMg4nG6/custom-config.yml"
+    - "--config=/var/folders/c4/dcr0mh3d183d5kh9gf89wsc00000gn/T/.tmp3dzQlZ/custom-config.yml"
 ---
 success: true
 exit_code: 0
@@ -15,22 +15,22 @@ exit_code: 0
 Available Components:
 ====================
 
-Component: test-builtins://create_messages
+Component: /test-builtins/create_messages
   Description: Create a chat message list from system instructions and user prompt
 
-Component: test-builtins://eval
+Component: /test-builtins/eval
   Description: Execute a nested workflow with given input and return the result
 
-Component: test-builtins://get_blob
+Component: /test-builtins/get_blob
   Description: Retrieve JSON data from a blob using its ID
 
-Component: test-builtins://load_file
+Component: /test-builtins/load_file
   Description: Load and parse a file (JSON, YAML, or text) from the filesystem
 
-Component: test-builtins://openai
+Component: /test-builtins/openai
   Description: Send messages to OpenAI's chat completion API and get a response
 
-Component: test-builtins://put_blob
+Component: /test-builtins/put_blob
   Description: Store JSON data as a blob and return its content-addressable ID
 
 Total components: 6

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_default.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_default.snap
@@ -15,22 +15,22 @@ exit_code: 0
 Available Components:
 ====================
 
-Component: builtin://create_messages
+Component: /builtin/create_messages
   Description: Create a chat message list from system instructions and user prompt
 
-Component: builtin://eval
+Component: /builtin/eval
   Description: Execute a nested workflow with given input and return the result
 
-Component: builtin://get_blob
+Component: /builtin/get_blob
   Description: Retrieve JSON data from a blob using its ID
 
-Component: builtin://load_file
+Component: /builtin/load_file
   Description: Load and parse a file (JSON, YAML, or text) from the filesystem
 
-Component: builtin://openai
+Component: /builtin/openai
   Description: Send messages to OpenAI's chat completion API and get a response
 
-Component: builtin://put_blob
+Component: /builtin/put_blob
   Description: Store JSON data as a blob and return its content-addressable ID
 
 Total components: 6

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
@@ -16,7 +16,7 @@ exit_code: 0
 {
   "components": [
     {
-      "component": "create_messages",
+      "component": "/builtin/create_messages",
       "description": "Create a chat message list from system instructions and user prompt",
       "input_schema": {
         "type": "object",
@@ -53,7 +53,7 @@ exit_code: 0
       }
     },
     {
-      "component": "eval",
+      "component": "/builtin/eval",
       "description": "Execute a nested workflow with given input and return the result",
       "input_schema": {
         "description": "Input for the eval component",
@@ -104,7 +104,7 @@ exit_code: 0
       }
     },
     {
-      "component": "get_blob",
+      "component": "/builtin/get_blob",
       "description": "Retrieve JSON data from a blob using its ID",
       "input_schema": {
         "description": "Input for the get_blob component",
@@ -133,7 +133,7 @@ exit_code: 0
       }
     },
     {
-      "component": "load_file",
+      "component": "/builtin/load_file",
       "description": "Load and parse a file (JSON, YAML, or text) from the filesystem",
       "input_schema": {
         "type": "object",
@@ -176,7 +176,7 @@ exit_code: 0
       }
     },
     {
-      "component": "openai",
+      "component": "/builtin/openai",
       "description": "Send messages to OpenAI's chat completion API and get a response",
       "input_schema": {
         "description": "Input for the OpenAI component",
@@ -234,7 +234,7 @@ exit_code: 0
       }
     },
     {
-      "component": "put_blob",
+      "component": "/builtin/put_blob",
       "description": "Store JSON data as a blob and return its content-addressable ID",
       "input_schema": {
         "description": "Input for the put_blob component",

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
@@ -14,7 +14,7 @@ success: true
 exit_code: 0
 ----- stdout -----
 components:
-- component: create_messages
+- component: /builtin/create_messages
   description: Create a chat message list from system instructions and user prompt
   input_schema:
     type: object
@@ -38,7 +38,7 @@ components:
           $ref: '#/$defs/ChatMessage'
     required:
     - messages
-- component: eval
+- component: /builtin/eval
   description: Execute a nested workflow with given input and return the result
   input_schema:
     description: Input for the eval component
@@ -74,7 +74,7 @@ components:
     required:
     - result
     - run_id
-- component: get_blob
+- component: /builtin/get_blob
   description: Retrieve JSON data from a blob using its ID
   input_schema:
     description: Input for the get_blob component
@@ -93,7 +93,7 @@ components:
         description: The JSON data stored in the blob
     required:
     - data
-- component: load_file
+- component: /builtin/load_file
   description: Load and parse a file (JSON, YAML, or text) from the filesystem
   input_schema:
     type: object
@@ -119,7 +119,7 @@ components:
     required:
     - data
     - metadata
-- component: openai
+- component: /builtin/openai
   description: Send messages to OpenAI's chat completion API and get a response
   input_schema:
     description: Input for the OpenAI component
@@ -160,7 +160,7 @@ components:
         type: string
     required:
     - response
-- component: put_blob
+- component: /builtin/put_blob
   description: Store JSON data as a blob and return its content-addressable ID
   input_schema:
     description: Input for the put_blob component

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_json_no_schemas.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_json_no_schemas.snap
@@ -17,27 +17,27 @@ exit_code: 0
 {
   "components": [
     {
-      "component": "create_messages",
+      "component": "/builtin/create_messages",
       "description": "Create a chat message list from system instructions and user prompt"
     },
     {
-      "component": "eval",
+      "component": "/builtin/eval",
       "description": "Execute a nested workflow with given input and return the result"
     },
     {
-      "component": "get_blob",
+      "component": "/builtin/get_blob",
       "description": "Retrieve JSON data from a blob using its ID"
     },
     {
-      "component": "load_file",
+      "component": "/builtin/load_file",
       "description": "Load and parse a file (JSON, YAML, or text) from the filesystem"
     },
     {
-      "component": "openai",
+      "component": "/builtin/openai",
       "description": "Send messages to OpenAI's chat completion API and get a response"
     },
     {
-      "component": "put_blob",
+      "component": "/builtin/put_blob",
       "description": "Store JSON data as a blob and return its content-addressable ID"
     }
   ]

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
@@ -16,7 +16,7 @@ exit_code: 0
 Available Components:
 ====================
 
-Component: builtin://create_messages
+Component: /builtin/create_messages
   Description: Create a chat message list from system instructions and user prompt
   Input Schema:
     {
@@ -54,7 +54,7 @@ Component: builtin://create_messages
       ]
     }
 
-Component: builtin://eval
+Component: /builtin/eval
   Description: Execute a nested workflow with given input and return the result
   Input Schema:
     {
@@ -106,7 +106,7 @@ Component: builtin://eval
       ]
     }
 
-Component: builtin://get_blob
+Component: /builtin/get_blob
   Description: Retrieve JSON data from a blob using its ID
   Input Schema:
     {
@@ -136,7 +136,7 @@ Component: builtin://get_blob
       ]
     }
 
-Component: builtin://load_file
+Component: /builtin/load_file
   Description: Load and parse a file (JSON, YAML, or text) from the filesystem
   Input Schema:
     {
@@ -180,7 +180,7 @@ Component: builtin://load_file
       ]
     }
 
-Component: builtin://openai
+Component: /builtin/openai
   Description: Send messages to OpenAI's chat completion API and get a response
   Input Schema:
     {
@@ -239,7 +239,7 @@ Component: builtin://openai
       ]
     }
 
-Component: builtin://put_blob
+Component: /builtin/put_blob
   Description: Store JSON data as a blob and return its content-addressable ID
   Input Schema:
     {

--- a/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
+++ b/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
@@ -67,9 +67,9 @@ async fn create_test_server(include_mocks: bool) -> (Router, Arc<StepFlowExecuto
     if include_mocks {
         let mut mock_plugin = MockPlugin::new();
 
-        // Configure mock://one_output component
+        // Configure /mock/one_output component
         mock_plugin
-            .mock_component("mock://one_output")
+            .mock_component("/mock/one_output")
             .behavior(
                 json!({"input": "first_step"}),
                 MockComponentBehavior::result(json!({"output": "step1_result"})),
@@ -79,9 +79,9 @@ async fn create_test_server(include_mocks: bool) -> (Router, Arc<StepFlowExecuto
                 MockComponentBehavior::result(json!({"output": "debug_result"})),
             );
 
-        // Configure mock://two_outputs component
+        // Configure /mock/two_outputs component
         mock_plugin
-            .mock_component("mock://two_outputs")
+            .mock_component("/mock/two_outputs")
             .behavior(
                 json!({"input": "step1_result"}),
                 MockComponentBehavior::result(json!({"x": 42, "y": 100})),
@@ -91,9 +91,9 @@ async fn create_test_server(include_mocks: bool) -> (Router, Arc<StepFlowExecuto
                 MockComponentBehavior::result(json!({"x": 99, "y": 200})),
             );
 
-        // Configure mock://error_component component
+        // Configure /mock/error_component component
         mock_plugin
-            .mock_component("mock://error_component")
+            .mock_component("/mock/error_component")
             .behavior(
                 json!({"input": "trigger_error"}),
                 MockComponentBehavior::result(FlowResult::Failed {
@@ -139,7 +139,7 @@ fn create_test_workflow() -> Flow {
         output_schema: None,
         steps: vec![Step {
             id: "test_step".to_string(),
-            component: Component::from_string("builtin://create_messages"),
+            component: Component::from_string("create_messages"),
             input: ValueTemplate::literal(json!({
                 "user_prompt": "Hello from test"
             })),
@@ -523,7 +523,7 @@ async fn test_status_updates_during_regular_execution() {
         steps: vec![
             Step {
                 id: "step1".to_string(),
-                component: Component::from_string("mock://one_output"),
+                component: Component::from_string("/mock/one_output"),
                 input: ValueTemplate::parse_value(json!({"input": "first_step"})).unwrap(),
                 input_schema: None,
                 output_schema: None,
@@ -532,7 +532,7 @@ async fn test_status_updates_during_regular_execution() {
             },
             Step {
                 id: "step2".to_string(),
-                component: Component::from_string("mock://two_outputs"),
+                component: Component::from_string("/mock/two_outputs"),
                 input: ValueTemplate::parse_value(json!({
                     "input": {
                         "$from": {"step": "step1"},
@@ -621,9 +621,9 @@ async fn test_status_updates_during_regular_execution() {
     let step2 = &steps["step2"];
 
     assert_eq!(step1["stepId"], "step1");
-    assert_eq!(step1["component"], "mock://one_output");
+    assert_eq!(step1["component"], "/mock/one_output");
     assert_eq!(step2["stepId"], "step2");
-    assert_eq!(step2["component"], "mock://two_outputs");
+    assert_eq!(step2["component"], "/mock/two_outputs");
 
     // With the standardized field naming, verify steps have a status field
     assert!(step1.get("status").is_some());
@@ -646,7 +646,7 @@ async fn test_status_updates_during_debug_execution() {
         steps: vec![
             Step {
                 id: "step1".to_string(),
-                component: Component::from_string("mock://one_output"),
+                component: Component::from_string("/mock/one_output"),
                 input: ValueTemplate::parse_value(json!({"input": "debug_step"})).unwrap(),
                 input_schema: None,
                 output_schema: None,
@@ -655,7 +655,7 @@ async fn test_status_updates_during_debug_execution() {
             },
             Step {
                 id: "step2".to_string(),
-                component: Component::from_string("mock://two_outputs"),
+                component: Component::from_string("/mock/two_outputs"),
                 input: ValueTemplate::parse_value(json!({
                     "input": {
                         "$from": {"step": "step1"},
@@ -745,9 +745,9 @@ async fn test_status_updates_during_debug_execution() {
 
     // Verify that status field is used consistently
     assert_eq!(step1["stepId"], "step1");
-    assert_eq!(step1["component"], "mock://one_output");
+    assert_eq!(step1["component"], "/mock/one_output");
     assert_eq!(step2["stepId"], "step2");
-    assert_eq!(step2["component"], "mock://two_outputs");
+    assert_eq!(step2["component"], "/mock/two_outputs");
 
     // Verify that steps have status information
     assert!(step1.get("status").is_some());
@@ -783,7 +783,7 @@ async fn test_status_transitions_with_error_handling() {
         output_schema: None,
         steps: vec![Step {
             id: "failing_step".to_string(),
-            component: Component::from_string("mock://error_component"),
+            component: Component::from_string("/mock/error_component"),
             input: ValueTemplate::literal(json!({"input": "trigger_error"})),
             input_schema: None,
             output_schema: None,
@@ -862,7 +862,7 @@ async fn test_status_transitions_with_error_handling() {
     // Much cleaner access with dictionary API
     let failing_step = &steps["failing_step"];
     assert_eq!(failing_step["stepId"], "failing_step");
-    assert_eq!(failing_step["component"], "mock://error_component");
+    assert_eq!(failing_step["component"], "/mock/error_component");
 
     // The key test for error handling is that the workflow overall failed (verified above)
     // and that step information is accessible via the improved dictionary API

--- a/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
@@ -61,7 +61,7 @@ mod tests {
             output: ValueTemplate::empty_object(),
             steps: vec![stepflow_core::workflow::Step {
                 id: "test_step".to_string(),
-                component: stepflow_core::workflow::Component::from_string("test://mock"),
+                component: stepflow_core::workflow::Component::from_string("/test/mock"),
                 input: ValueTemplate::empty_object(),
                 input_schema: None,
                 output_schema: None,

--- a/stepflow-rs/tests/basic.yaml
+++ b/stepflow-rs/tests/basic.yaml
@@ -2,7 +2,7 @@ name: Basic Test Workflow
 description: Simple workflow to test the new test command
 steps:
 - id: message_step
-  component: builtin://create_messages
+  component: create_messages
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/builtins/blob_test.yaml
+++ b/stepflow-rs/tests/builtins/blob_test.yaml
@@ -12,7 +12,7 @@ output_schema:
       type: object
 steps:
 - id: put_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -21,7 +21,7 @@ steps:
         workflow: input
       path: data
 - id: get_blob
-  component: builtin://get_blob
+  component: get_blob
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/builtins/nested_eval.yaml
+++ b/stepflow-rs/tests/builtins/nested_eval.yaml
@@ -2,7 +2,7 @@ name: nested_eval_test
 description: Test nested flow execution with eval component
 steps:
 - id: nested_flow
-  component: builtin://eval
+  component: eval
   input_schema: null
   output_schema: null
   input:
@@ -11,7 +11,7 @@ steps:
         name: simple_nested
         steps:
         - id: inner_step
-          component: builtin://create_messages
+          component: create_messages
           input:
             user_prompt: Hello from nested flow
         output:

--- a/stepflow-rs/tests/mcp/basic_mcp.yaml
+++ b/stepflow-rs/tests/mcp/basic_mcp.yaml
@@ -8,7 +8,7 @@ output:
 
 steps:
   - id: test_step
-    component: builtin://stepflow-builtins/eval
+    component: eval
     input:
       expr: '"Testing MCP integration: " + $.input.message'
     output: result

--- a/stepflow-rs/tests/mock/basic.yaml
+++ b/stepflow-rs/tests/mock/basic.yaml
@@ -14,7 +14,7 @@ output_schema:
       type: integer
 steps:
 - id: step1
-  component: mock://one_output
+  component: /mock/one_output
   input_schema: null
   output_schema: null
   input:
@@ -23,7 +23,7 @@ steps:
         workflow: input
       path: name
 - id: step2
-  component: mock://two_outputs
+  component: /mock/two_outputs
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/mock/conditional_skip.yaml
+++ b/stepflow-rs/tests/mock/conditional_skip.yaml
@@ -14,7 +14,7 @@ outputSchema:
       type: string
 steps:
 - id: conditional_step
-  component: mock://one_output
+  component: /mock/one_output
   inputSchema: null
   outputSchema: null
   skipIf:
@@ -27,7 +27,7 @@ steps:
         workflow: input
       path: value
 - id: dependent_step
-  component: mock://handle_skip
+  component: /mock/handle_skip
   inputSchema: null
   outputSchema: null
   input:

--- a/stepflow-rs/tests/mock/conditional_skip_use_default.yaml
+++ b/stepflow-rs/tests/mock/conditional_skip_use_default.yaml
@@ -14,7 +14,7 @@ outputSchema:
       type: string
 steps:
 - id: conditional_step
-  component: mock://one_output
+  component: /mock/one_output
   inputSchema: null
   outputSchema: null
   skipIf:
@@ -27,7 +27,7 @@ steps:
         workflow: input
       path: value
 - id: dependent_step
-  component: mock://handle_skip
+  component: /mock/handle_skip
   inputSchema: null
   outputSchema: null
   input:

--- a/stepflow-rs/tests/mock/error_fail.yaml
+++ b/stepflow-rs/tests/mock/error_fail.yaml
@@ -7,7 +7,7 @@ output_schema:
       type: string
 steps:
 - id: error
-  component: mock://error
+  component: /mock/error
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/mock/error_skip.yaml
+++ b/stepflow-rs/tests/mock/error_skip.yaml
@@ -7,7 +7,7 @@ outputSchema:
       type: string
 steps:
 - id: error
-  component: mock://error
+  component: /mock/error
   inputSchema: null
   outputSchema: null
   onError:

--- a/stepflow-rs/tests/mock/error_use_default.yaml
+++ b/stepflow-rs/tests/mock/error_use_default.yaml
@@ -7,7 +7,7 @@ outputSchema:
       type: string
 steps:
 - id: error
-  component: mock://error
+  component: /mock/error
   inputSchema: null
   outputSchema: null
   onError:

--- a/stepflow-rs/tests/mock/error_use_default_value.yaml
+++ b/stepflow-rs/tests/mock/error_use_default_value.yaml
@@ -7,7 +7,7 @@ outputSchema:
       type: string
 steps:
 - id: error
-  component: mock://error
+  component: /mock/error
   inputSchema: null
   outputSchema: null
   onError:

--- a/stepflow-rs/tests/mock/stepflow-config.yml
+++ b/stepflow-rs/tests/mock/stepflow-config.yml
@@ -2,7 +2,7 @@ plugins:
   - name: mock
     type: mock
     components:
-      mock://one_output:
+      /mock/one_output:
         input_schema:
           type: object
           properties:
@@ -20,7 +20,7 @@ plugins:
           { input: "hello"}:
             outcome: success
             result: {output: world}
-      mock://two_outputs:
+      /mock/two_outputs:
         input_schema:
           type: object
           properties:
@@ -40,7 +40,7 @@ plugins:
           { input: "world"}:
             outcome: success
             result: {x: 2, y: 8}
-      mock://error:
+      /mock/error:
         input_schema:
           type: object
           properties:
@@ -58,7 +58,7 @@ plugins:
           { mode: "succeed" }:
             outcome: success
             result: {output: "succeeded"}
-      mock://handle_skip:
+      /mock/handle_skip:
         input_schema:
           type: object
           properties:

--- a/stepflow-rs/tests/no_tests.yaml
+++ b/stepflow-rs/tests/no_tests.yaml
@@ -3,7 +3,7 @@ description: This workflow has no test section and should be skipped
 
 steps:
   - id: simple_step
-    component: builtin://eval
+    component: eval
     input:
       expression: '"This workflow has no tests"'
 

--- a/stepflow-rs/tests/python/blob_integration.yaml
+++ b/stepflow-rs/tests/python/blob_integration.yaml
@@ -17,13 +17,13 @@ output_schema:
 steps:
   # Step 1: Store initial data as blob using builtin component
   - id: store_original_data
-    component: builtin://put_blob
+    component: put_blob
     input:
       data: { $from: { workflow: input }, path: user_data }
 
   # Step 2: Create blob for Python function definition
   - id: create_process_data_blob
-    component: builtin://put_blob
+    component: put_blob
     input:
       data:
         input_schema:
@@ -61,7 +61,7 @@ steps:
 
   # Step 3: Python UDF retrieves blob and processes it
   - id: process_blob_data
-    component: python://udf
+    component: /python/udf
     input:
       blob_id: { $from: { step: create_process_data_blob }, path: blob_id }
       input:
@@ -70,7 +70,7 @@ steps:
 
   # Step 4: Retrieve final processed data using builtin component
   - id: get_final_result
-    component: builtin://get_blob
+    component: get_blob
     input:
       blob_id: { $from: { step: process_blob_data }, path: processed_blob_id }
 

--- a/stepflow-rs/tests/python/blob_simple.yaml
+++ b/stepflow-rs/tests/python/blob_simple.yaml
@@ -16,7 +16,7 @@ output_schema:
       type: object
 steps:
 - id: store_with_builtin
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -32,7 +32,7 @@ steps:
       timestamp: 2024-01-01T00:00:00Z
 # Create blob for Python function definition
 - id: create_store_data_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -60,7 +60,7 @@ steps:
           return {'blob_id': blob_id, 'status': 'success'}
       function_name: store_data
 - id: store_with_python
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:
@@ -78,7 +78,7 @@ steps:
           workflow: input
         path: number
 - id: retrieve_with_builtin
-  component: builtin://get_blob
+  component: get_blob
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/python/udf_function.yaml
+++ b/stepflow-rs/tests/python/udf_function.yaml
@@ -17,7 +17,7 @@ output_schema:
       type: object
 steps:
 - id: create_analyze_scores_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -39,7 +39,7 @@ steps:
       code: "def analyze_scores(input):\n    scores = [item['score'] for item in input['data']]\n    \n    if not scores:\n        return {\n            'count': 0,\n            'average': 0,\n            'min': 0,\n            'max': 0,\n            'top_performer': None\n        }\n    \n    average = sum(scores) / len(scores)\n    min_score = min(scores)\n    max_score = max(scores)\n    \n    # Find top performer\n    top_performer = None\n    for item in input['data']:\n        if item['score'] == max_score:\n            top_performer = item['name']\n            break\n    \n    return {\n        'count': len(scores),\n        'average': round(average, 2),\n        'min': min_score,\n        'max': max_score,\n        'top_performer': top_performer\n    }\n"
       function_name: analyze_scores
 - id: analyze_scores
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/python/udf_simple.yaml
+++ b/stepflow-rs/tests/python/udf_simple.yaml
@@ -17,7 +17,7 @@ output_schema:
 steps:
 # Create blobs for function definitions
 - id: create_addition_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -34,7 +34,7 @@ steps:
         - y
       code: input['x'] + input['y']
 - id: create_multiplication_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -51,7 +51,7 @@ steps:
         - y
       code: input['x'] * input['y']
 - id: create_complex_calculation_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -69,7 +69,7 @@ steps:
       code: math.sqrt(input['sum'] ** 2 + input['product'] ** 2)
 # Execute functions using blob_ids
 - id: simple_addition
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:
@@ -87,7 +87,7 @@ steps:
           workflow: input
         path: y
 - id: simple_multiplication
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:
@@ -105,7 +105,7 @@ steps:
           workflow: input
         path: y
 - id: complex_calculation
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/python/udf_text_processing.yaml
+++ b/stepflow-rs/tests/python/udf_text_processing.yaml
@@ -17,7 +17,7 @@ output_schema:
 steps:
 # Create blobs for function definitions
 - id: create_word_analysis_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -57,7 +57,7 @@ steps:
             'most_common_words': [{'word': word, 'count': count} for word, count in most_common]
         }
 - id: create_pattern_search_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -82,7 +82,7 @@ steps:
         except:
             return []
 - id: create_sentiment_analysis_blob
-  component: builtin://put_blob
+  component: put_blob
   input_schema: null
   output_schema: null
   input:
@@ -114,7 +114,7 @@ steps:
         return round(sentiment_score, 2)
 # Execute functions using blob_ids
 - id: word_analysis
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:
@@ -128,7 +128,7 @@ steps:
           workflow: input
         path: text
 - id: pattern_search
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:
@@ -146,7 +146,7 @@ steps:
           workflow: input
         path: pattern
 - id: sentiment_analysis
-  component: python://udf
+  component: /python/udf
   input_schema: null
   output_schema: null
   input:

--- a/stepflow-rs/tests/sql-state/simple_workflow.yaml
+++ b/stepflow-rs/tests/sql-state/simple_workflow.yaml
@@ -10,7 +10,7 @@ input:
 
 steps:
   - id: process_message
-    component: mock://identity
+    component: /mock/identity
     input:
       value: {$from: { workflow: input }, path: message }
 

--- a/stepflow-rs/tests/sql-state/stepflow-config.yml
+++ b/stepflow-rs/tests/sql-state/stepflow-config.yml
@@ -2,7 +2,7 @@ plugins:
   - name: mock
     type: mock
     components:
-      mock://identity:
+      /mock/identity:
         input_schema:
           type: object
           properties:


### PR DESCRIPTION
Replace URL-based component references (e.g., "plugin://component") with path-based references (e.g., "/plugin/component").

This better aligns with the use of globs to match component paths, since globs aren't defined over URLs.

- Update Component struct to use path instead of url
- Update parsing logic to handle path-based syntax
- Update all tests to use new path format
- Maintain builtin component support without leading slash