### PR TITLE
feat: Add path transformations for routing

### DIFF
--- a/stepflow-rs/Cargo.lock
+++ b/stepflow-rs/Cargo.lock
@@ -3311,6 +3311,7 @@ dependencies = [
 name = "stepflow-plugin"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "dynosaur",
  "error-stack",
  "futures",
@@ -3321,6 +3322,7 @@ dependencies = [
  "stepflow-core",
  "stepflow-state",
  "thiserror 2.0.12",
+ "tokio",
  "trait-variant",
  "uuid",
 ]

--- a/stepflow-rs/crates/stepflow-execution/src/executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/executor.rs
@@ -116,9 +116,34 @@ impl StepFlowExecutor {
             .change_context(ExecutionError::RouterError)
     }
 
+    pub async fn get_plugin_with_transformed_path(
+        &self,
+        component: &Component,
+        input: ValueRef,
+    ) -> Result<(&Arc<DynPlugin<'static>>, Component)> {
+        // Use the integrated plugin router to get the plugin and transformed path
+        self.plugin_router
+            .get_plugin_with_transformed_path(component.path_string(), input)
+            .change_context(ExecutionError::RouterError)
+    }
+
     /// List all registered plugins
     pub async fn list_plugins(&self) -> Vec<&Arc<DynPlugin<'static>>> {
         self.plugin_router.plugins().collect()
+    }
+
+    /// Get the plugin router for advanced routing operations
+    pub fn plugin_router(&self) -> &PluginRouter {
+        &self.plugin_router
+    }
+
+    /// List components with routing context applied
+    /// This method applies component filtering and reverse path transformation
+    pub async fn list_components_with_routing(&self) -> Result<Vec<stepflow_core::component::ComponentInfo>> {
+        self.plugin_router
+            .list_components_with_routing()
+            .await
+            .change_context(ExecutionError::PluginError)
     }
 
     /// Get or create a debug session for step-by-step execution control

--- a/stepflow-rs/crates/stepflow-plugin/Cargo.toml
+++ b/stepflow-rs/crates/stepflow-plugin/Cargo.toml
@@ -30,3 +30,5 @@ trait-variant.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
+tokio.workspace = true

--- a/stepflow-rs/crates/stepflow-plugin/src/error.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/error.rs
@@ -44,6 +44,8 @@ pub enum PluginError {
     InvalidRuleIndex(usize),
     #[error("plugin not found: {0}")]
     PluginNotFound(String),
+    #[error("configuration error")]
+    Configuration,
 }
 
 pub type Result<T, E = error_stack::Report<PluginError>> = std::result::Result<T, E>;

--- a/stepflow-rs/crates/stepflow-plugin/src/routing.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing.rs
@@ -14,7 +14,9 @@
 pub mod plugin_router;
 mod router;
 mod rules;
+mod transform;
 
 pub use plugin_router::{PluginRouter, PluginRouterBuilder};
 pub use router::{ComponentRouter, Router, RouterError};
-pub use rules::{InputCondition, MatchRule, RoutingRule};
+pub use rules::{InputCondition, MatchRule, RoutingRule, RoutingTarget, Target};
+pub use transform::{ComponentFilter, PathTransformer};

--- a/stepflow-rs/crates/stepflow-plugin/src/routing/plugin_router.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing/plugin_router.rs
@@ -14,11 +14,11 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::Router;
+use super::{Router, PathTransformer};
 use crate::routing::RoutingRule;
-use crate::{DynPlugin, PluginError, Result};
+use crate::{DynPlugin, PluginError, Result, Plugin};
 use error_stack::ResultExt as _;
-use stepflow_core::workflow::ValueRef;
+use stepflow_core::workflow::{Component, ValueRef};
 
 /// Integrated plugin router that combines routing logic with plugin management.
 ///
@@ -33,6 +33,11 @@ pub struct PluginRouter {
     /// Unique plugin instances (no duplicates)
     /// Used for initialization to ensure each plugin is only initialized once
     unique_plugins: Vec<Arc<DynPlugin<'static>>>,
+    /// Path transformers indexed by routing rule index
+    /// Used to transform component paths before sending to plugins
+    transformers: Vec<PathTransformer>,
+    /// Original routing rules for component listing and reverse transformation
+    routing_rules: Vec<RoutingRule>,
 }
 
 impl PluginRouter {
@@ -47,11 +52,16 @@ impl PluginRouter {
         component_path: &str,
         input: ValueRef,
     ) -> Result<&Arc<DynPlugin<'static>>> {
-        // NOTE: If the component router step is expensive, we could instead
-        // have this return the `ComponentRouter` and allow the caller to store
-        // that. This would allow determining if there is a static route, as
-        // well as re-using the path based routing.
+        let (plugin, _) = self.get_plugin_with_transformed_path(component_path, input)?;
+        Ok(plugin)
+    }
 
+    /// Get a plugin and transformed component path for the given component path and input data
+    pub fn get_plugin_with_transformed_path(
+        &self,
+        component_path: &str,
+        input: ValueRef,
+    ) -> Result<(&Arc<DynPlugin<'static>>, Component)> {
         // Route the component path to get a component router
         let component_router = self
             .router
@@ -64,16 +74,82 @@ impl PluginRouter {
             .change_context(PluginError::InvalidInput)?;
 
         // Get the plugin directly by rule index
-        self.plugins
+        let plugin = self.plugins
             .get(rule_index)
-            .ok_or(PluginError::InvalidRuleIndex(rule_index))
-            .map_err(|e| e.into())
+            .ok_or(PluginError::InvalidRuleIndex(rule_index))?;
+
+        // Transform the component path using the corresponding transformer
+        let transformer = self.transformers
+            .get(rule_index)
+            .ok_or(PluginError::InvalidRuleIndex(rule_index))?;
+        
+        let transformed_path = transformer
+            .transform_to_plugin(component_path)
+            .change_context(PluginError::InvalidInput)?;
+        
+        let transformed_component = Component::from_string(&transformed_path);
+
+        Ok((plugin, transformed_component))
     }
 
     /// Get all registered plugins
     /// This returns each plugin exactly once, even if it's used by multiple routing rules
     pub fn plugins(&self) -> impl Iterator<Item = &Arc<DynPlugin<'static>>> {
         self.unique_plugins.iter()
+    }
+
+    /// List components with routing context applied
+    /// This method queries all plugins for their components and applies:
+    /// 1. Component filtering based on routing rules
+    /// 2. Reverse path transformation to show components as they appear through routing
+    pub async fn list_components_with_routing(&self) -> Result<Vec<stepflow_core::component::ComponentInfo>> {
+        use crate::routing::{ComponentFilter, PathTransformer};
+        use stepflow_core::component::ComponentInfo;
+        
+        let mut all_components = Vec::new();
+        
+        // Process each routing rule
+        for (rule_index, rule) in self.routing_rules.iter().enumerate() {
+            // Get the plugin for this rule
+            let plugin = self.plugins.get(rule_index).ok_or(PluginError::InvalidRuleIndex(rule_index))?;
+            
+            // Get all components from this plugin
+            let plugin_components = plugin.list_components().await?;
+            
+            // Create component filter for this rule
+            let match_pattern = &rule.match_rule[0].component; // Use first match pattern
+            let routing_target = rule.target.as_routing_target(match_pattern);
+            let component_filter = ComponentFilter::from_target(&routing_target)?;
+            let path_transformer = PathTransformer::from_target(&routing_target);
+            
+            // Filter and transform components
+            for component_info in plugin_components {
+                // Apply component filter
+                if !component_filter.matches_component(&component_info.component) {
+                    continue;
+                }
+                
+                // Apply reverse path transformation
+                let transformed_path = path_transformer.transform_from_plugin(component_info.component.path_string());
+                let transformed_component = Component::from_string(&transformed_path);
+                
+                // Create new component info with transformed path
+                let transformed_info = ComponentInfo {
+                    component: transformed_component,
+                    description: component_info.description,
+                    input_schema: component_info.input_schema,
+                    output_schema: component_info.output_schema,
+                };
+                
+                all_components.push(transformed_info);
+            }
+        }
+        
+        // Remove duplicates and sort
+        all_components.sort_by(|a, b| a.component.to_string().cmp(&b.component.to_string()));
+        all_components.dedup_by(|a, b| a.component == b.component);
+        
+        Ok(all_components)
     }
 }
 
@@ -115,25 +191,36 @@ impl PluginRouterBuilder {
     pub fn build(self) -> Result<PluginRouter> {
         // Expand the plugins HashMap into a Vec where each index corresponds to a routing rule
         let mut plugins = Vec::new();
+        let mut transformers = Vec::new();
+        
         for rule in self.routing_rules.iter() {
-            let plugin_name = rule.target.as_ref();
+            let plugin_name = rule.target.plugin();
             if let Some(plugin) = self.plugins.get(plugin_name) {
                 plugins.push(plugin.clone());
             } else {
                 return Err(PluginError::PluginNotFound(plugin_name.to_string()).into());
             }
+            
+            // Create path transformer for each rule
+            // For simple targets, auto-detect strip segments from the first match pattern
+            let match_pattern = &rule.match_rule[0].component; // Use first match pattern for auto-detection
+            let routing_target = rule.target.as_routing_target(match_pattern);
+            let transformer = PathTransformer::from_target(&routing_target);
+            transformers.push(transformer);
         }
 
         // Create a vector of unique plugins (no duplicates)
         let unique_plugins: Vec<Arc<DynPlugin<'static>>> = self.plugins.into_values().collect();
 
         // Create the underlying router
-        let router = Router::new(self.routing_rules).change_context(PluginError::CreatePlugin)?;
+        let router = Router::new(self.routing_rules.clone()).change_context(PluginError::CreatePlugin)?;
 
         Ok(PluginRouter {
             router,
             plugins,
             unique_plugins,
+            transformers,
+            routing_rules: self.routing_rules,
         })
     }
 }
@@ -252,5 +339,500 @@ mod tests {
         let result = PluginRouter::builder().with_routing_rules(rules).build();
 
         assert!(result.is_err());
+    }
+
+    // Component listing tests
+    #[tokio::test]
+    async fn test_component_listing_with_path_transformation() {
+        use crate::routing::rules::{RoutingTarget, Target};
+        use stepflow_core::component::ComponentInfo;
+        use stepflow_core::workflow::Component;
+
+        // Create a mock plugin that reports components with simple names
+        struct MockPlugin;
+        
+        impl crate::Plugin for MockPlugin {
+            async fn init(&self, _context: &Arc<dyn crate::Context>) -> crate::Result<()> {
+                Ok(())
+            }
+
+            async fn list_components(&self) -> crate::Result<Vec<ComponentInfo>> {
+                Ok(vec![
+                    ComponentInfo {
+                        component: Component::from_string("/udf"),
+                        description: Some("User-defined function".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/analyzer"),
+                        description: Some("Data analyzer".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/debug_tool"),
+                        description: Some("Debug tool".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                ])
+            }
+
+            async fn component_info(&self, component: &Component) -> crate::Result<ComponentInfo> {
+                match component.path_string() {
+                    "/udf" => Ok(ComponentInfo {
+                        component: component.clone(),
+                        description: Some("User-defined function".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    }),
+                    "/analyzer" => Ok(ComponentInfo {
+                        component: component.clone(),
+                        description: Some("Data analyzer".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    }),
+                    "/debug_tool" => Ok(ComponentInfo {
+                        component: component.clone(),
+                        description: Some("Debug tool".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    }),
+                    _ => Err(crate::PluginError::UnknownComponent(component.clone()).into()),
+                }
+            }
+
+            async fn execute(
+                &self,
+                _component: &Component,
+                _context: crate::ExecutionContext,
+                _input: stepflow_core::values::ValueRef,
+            ) -> crate::Result<stepflow_core::FlowResult> {
+                Ok(stepflow_core::FlowResult::Success {
+                    result: stepflow_core::values::ValueRef::new(serde_json::json!({"mock": "result"})),
+                })
+            }
+        }
+
+        // Create routing rules with path transformation and component filtering
+        let rules = vec![
+            RoutingRule {
+                match_rule: vec![MatchRule {
+                    component: "/python/*".to_string(),
+                    input: vec![],
+                }],
+                target: Target::Complex(RoutingTarget {
+                    plugin: "python".to_string(),
+                    strip_segments: vec!["python".to_string()],
+                    components: Some(vec!["udf".to_string(), "analyzer".to_string()]),
+                    exclude_components: Some(vec!["debug_*".to_string()]),
+                }),
+            },
+        ];
+
+        let plugin_router = PluginRouter::builder()
+            .with_routing_rules(rules)
+            .register_plugin("python".to_string(), DynPlugin::boxed(MockPlugin))
+            .build()
+            .unwrap();
+
+        // Test component listing with routing
+        let components = plugin_router.list_components_with_routing().await.unwrap();
+
+        // Should have 2 components: udf and analyzer (debug_tool filtered out)
+        assert_eq!(components.len(), 2);
+
+        // Check that paths are transformed correctly
+        let component_paths: Vec<String> = components.iter().map(|c| c.component.to_string()).collect();
+        assert!(component_paths.contains(&"/python/udf".to_string()));
+        assert!(component_paths.contains(&"/python/analyzer".to_string()));
+        assert!(!component_paths.contains(&"/python/debug_tool".to_string()));
+
+        // Check descriptions are preserved
+        let udf_component = components.iter().find(|c| c.component.to_string() == "/python/udf").unwrap();
+        assert_eq!(udf_component.description, Some("User-defined function".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_component_listing_with_multiple_segments() {
+        use crate::routing::rules::{RoutingTarget, Target};
+        use stepflow_core::component::ComponentInfo;
+        use stepflow_core::workflow::Component;
+
+        struct MockPlugin;
+        
+        impl crate::Plugin for MockPlugin {
+            async fn init(&self, _context: &Arc<dyn crate::Context>) -> crate::Result<()> {
+                Ok(())
+            }
+
+            async fn list_components(&self) -> crate::Result<Vec<ComponentInfo>> {
+                Ok(vec![
+                    ComponentInfo {
+                        component: Component::from_string("/classifier"),
+                        description: Some("ML classifier".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/regressor"),
+                        description: Some("ML regressor".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                ])
+            }
+
+            async fn component_info(&self, component: &Component) -> crate::Result<ComponentInfo> {
+                match component.path_string() {
+                    "/classifier" => Ok(ComponentInfo {
+                        component: component.clone(),
+                        description: Some("ML classifier".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    }),
+                    "/regressor" => Ok(ComponentInfo {
+                        component: component.clone(),
+                        description: Some("ML regressor".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    }),
+                    _ => Err(crate::PluginError::UnknownComponent(component.clone()).into()),
+                }
+            }
+
+            async fn execute(
+                &self,
+                _component: &Component,
+                _context: crate::ExecutionContext,
+                _input: stepflow_core::values::ValueRef,
+            ) -> crate::Result<stepflow_core::FlowResult> {
+                Ok(stepflow_core::FlowResult::Success {
+                    result: stepflow_core::values::ValueRef::new(serde_json::json!({"mock": "result"})),
+                })
+            }
+        }
+
+        // Create routing rules with multiple strip segments
+        let rules = vec![
+            RoutingRule {
+                match_rule: vec![MatchRule {
+                    component: "/ai/python/ml/*".to_string(),
+                    input: vec![],
+                }],
+                target: Target::Complex(RoutingTarget {
+                    plugin: "ml".to_string(),
+                    strip_segments: vec!["ai".to_string(), "python".to_string(), "ml".to_string()],
+                    components: None,
+                    exclude_components: None,
+                }),
+            },
+        ];
+
+        let plugin_router = PluginRouter::builder()
+            .with_routing_rules(rules)
+            .register_plugin("ml".to_string(), DynPlugin::boxed(MockPlugin))
+            .build()
+            .unwrap();
+
+        // Test component listing with routing
+        let components = plugin_router.list_components_with_routing().await.unwrap();
+
+        // Should have 2 components with the full path prefix
+        assert_eq!(components.len(), 2);
+
+        let component_paths: Vec<String> = components.iter().map(|c| c.component.to_string()).collect();
+        assert!(component_paths.contains(&"/ai/python/ml/classifier".to_string()));
+        assert!(component_paths.contains(&"/ai/python/ml/regressor".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_component_listing_with_include_exclude_filters() {
+        use crate::routing::rules::{RoutingTarget, Target};
+        use stepflow_core::component::ComponentInfo;
+        use stepflow_core::workflow::Component;
+
+        struct MockPlugin;
+        
+        impl crate::Plugin for MockPlugin {
+            async fn init(&self, _context: &Arc<dyn crate::Context>) -> crate::Result<()> {
+                Ok(())
+            }
+
+            async fn list_components(&self) -> crate::Result<Vec<ComponentInfo>> {
+                Ok(vec![
+                    ComponentInfo {
+                        component: Component::from_string("/ml_classifier"),
+                        description: Some("ML classifier".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/ml_regressor"),
+                        description: Some("ML regressor".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/ml_debug_tool"),
+                        description: Some("Debug tool".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/data_processor"),
+                        description: Some("Data processor".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/other_tool"),
+                        description: Some("Other tool".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                ])
+            }
+
+            async fn component_info(&self, component: &Component) -> crate::Result<ComponentInfo> {
+                // Simple implementation for testing
+                Ok(ComponentInfo {
+                    component: component.clone(),
+                    description: Some("Mock component".to_string()),
+                    input_schema: None,
+                    output_schema: None,
+                })
+            }
+
+            async fn execute(
+                &self,
+                _component: &Component,
+                _context: crate::ExecutionContext,
+                _input: stepflow_core::values::ValueRef,
+            ) -> crate::Result<stepflow_core::FlowResult> {
+                Ok(stepflow_core::FlowResult::Success {
+                    result: stepflow_core::values::ValueRef::new(serde_json::json!({"mock": "result"})),
+                })
+            }
+        }
+
+        // Create routing rules with include and exclude filters
+        let rules = vec![
+            RoutingRule {
+                match_rule: vec![MatchRule {
+                    component: "/ai/*".to_string(),
+                    input: vec![],
+                }],
+                target: Target::Complex(RoutingTarget {
+                    plugin: "ai".to_string(),
+                    strip_segments: vec!["ai".to_string()],
+                    components: Some(vec!["ml_*".to_string(), "data_*".to_string()]),
+                    exclude_components: Some(vec!["*_debug_*".to_string()]),
+                }),
+            },
+        ];
+
+        let plugin_router = PluginRouter::builder()
+            .with_routing_rules(rules)
+            .register_plugin("ai".to_string(), DynPlugin::boxed(MockPlugin))
+            .build()
+            .unwrap();
+
+        // Test component listing with routing
+        let components = plugin_router.list_components_with_routing().await.unwrap();
+
+        // Should have 3 components: ml_classifier, ml_regressor, data_processor
+        // ml_debug_tool excluded by exclude filter, other_tool excluded by include filter
+        assert_eq!(components.len(), 3);
+
+        let component_paths: Vec<String> = components.iter().map(|c| c.component.to_string()).collect();
+        assert!(component_paths.contains(&"/ai/ml_classifier".to_string()));
+        assert!(component_paths.contains(&"/ai/ml_regressor".to_string()));
+        assert!(component_paths.contains(&"/ai/data_processor".to_string()));
+        assert!(!component_paths.contains(&"/ai/ml_debug_tool".to_string()));
+        assert!(!component_paths.contains(&"/ai/other_tool".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_component_listing_with_multiple_routes_same_plugin() {
+        use crate::routing::rules::{RoutingTarget, Target};
+        use stepflow_core::component::ComponentInfo;
+        use stepflow_core::workflow::Component;
+
+        struct MockPlugin;
+        
+        impl crate::Plugin for MockPlugin {
+            async fn init(&self, _context: &Arc<dyn crate::Context>) -> crate::Result<()> {
+                Ok(())
+            }
+
+            async fn list_components(&self) -> crate::Result<Vec<ComponentInfo>> {
+                Ok(vec![
+                    ComponentInfo {
+                        component: Component::from_string("/udf"),
+                        description: Some("User-defined function".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/analyzer"),
+                        description: Some("Data analyzer".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/transformer"),
+                        description: Some("Data transformer".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                ])
+            }
+
+            async fn component_info(&self, component: &Component) -> crate::Result<ComponentInfo> {
+                Ok(ComponentInfo {
+                    component: component.clone(),
+                    description: Some("Mock component".to_string()),
+                    input_schema: None,
+                    output_schema: None,
+                })
+            }
+
+            async fn execute(
+                &self,
+                _component: &Component,
+                _context: crate::ExecutionContext,
+                _input: stepflow_core::values::ValueRef,
+            ) -> crate::Result<stepflow_core::FlowResult> {
+                Ok(stepflow_core::FlowResult::Success {
+                    result: stepflow_core::values::ValueRef::new(serde_json::json!({"mock": "result"})),
+                })
+            }
+        }
+
+        // Create multiple routing rules pointing to the same plugin with different filters
+        let rules = vec![
+            RoutingRule {
+                match_rule: vec![MatchRule {
+                    component: "/basic/python/*".to_string(),
+                    input: vec![],
+                }],
+                target: Target::Complex(RoutingTarget {
+                    plugin: "python".to_string(),
+                    strip_segments: vec!["basic".to_string(), "python".to_string()],
+                    components: Some(vec!["udf".to_string()]),
+                    exclude_components: None,
+                }),
+            },
+            RoutingRule {
+                match_rule: vec![MatchRule {
+                    component: "/advanced/python/*".to_string(),
+                    input: vec![],
+                }],
+                target: Target::Complex(RoutingTarget {
+                    plugin: "python".to_string(),
+                    strip_segments: vec!["advanced".to_string(), "python".to_string()],
+                    components: Some(vec!["analyzer".to_string(), "transformer".to_string()]),
+                    exclude_components: None,
+                }),
+            },
+        ];
+
+        let plugin_router = PluginRouter::builder()
+            .with_routing_rules(rules)
+            .register_plugin("python".to_string(), DynPlugin::boxed(MockPlugin))
+            .build()
+            .unwrap();
+
+        // Test component listing with routing
+        let components = plugin_router.list_components_with_routing().await.unwrap();
+
+        // Should have 3 components total (no duplicates)
+        assert_eq!(components.len(), 3);
+
+        let component_paths: Vec<String> = components.iter().map(|c| c.component.to_string()).collect();
+        assert!(component_paths.contains(&"/basic/python/udf".to_string()));
+        assert!(component_paths.contains(&"/advanced/python/analyzer".to_string()));
+        assert!(component_paths.contains(&"/advanced/python/transformer".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_component_listing_with_simple_targets() {
+        use stepflow_core::component::ComponentInfo;
+        use stepflow_core::workflow::Component;
+
+        struct MockPlugin;
+        
+        impl crate::Plugin for MockPlugin {
+            async fn init(&self, _context: &Arc<dyn crate::Context>) -> crate::Result<()> {
+                Ok(())
+            }
+
+            async fn list_components(&self) -> crate::Result<Vec<ComponentInfo>> {
+                // Mock plugin returns components with plugin prefix (like builtin plugins)
+                Ok(vec![
+                    ComponentInfo {
+                        component: Component::from_string("/python/component1"),
+                        description: Some("Component 1".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                    ComponentInfo {
+                        component: Component::from_string("/python/component2"),
+                        description: Some("Component 2".to_string()),
+                        input_schema: None,
+                        output_schema: None,
+                    },
+                ])
+            }
+
+            async fn component_info(&self, component: &Component) -> crate::Result<ComponentInfo> {
+                Ok(ComponentInfo {
+                    component: component.clone(),
+                    description: Some("Mock component".to_string()),
+                    input_schema: None,
+                    output_schema: None,
+                })
+            }
+
+            async fn execute(
+                &self,
+                _component: &Component,
+                _context: crate::ExecutionContext,
+                _input: stepflow_core::values::ValueRef,
+            ) -> crate::Result<stepflow_core::FlowResult> {
+                Ok(stepflow_core::FlowResult::Success {
+                    result: stepflow_core::values::ValueRef::new(serde_json::json!({"mock": "result"})),
+                })
+            }
+        }
+
+        // Create routing rules with simple targets (no auto-detected path transformation)
+        let rules = vec![
+            RoutingRule {
+                match_rule: vec![MatchRule {
+                    component: "/python/*".to_string(),
+                    input: vec![],
+                }],
+                target: "python".into(),
+            },
+        ];
+
+        let plugin_router = PluginRouter::builder()
+            .with_routing_rules(rules)
+            .register_plugin("python".to_string(), DynPlugin::boxed(MockPlugin))
+            .build()
+            .unwrap();
+
+        // Test component listing with routing
+        let components = plugin_router.list_components_with_routing().await.unwrap();
+
+        // Should have 2 components with no path transformation (plugin already returns full paths)
+        assert_eq!(components.len(), 2);
+
+        let component_paths: Vec<String> = components.iter().map(|c| c.component.to_string()).collect();
+        assert!(component_paths.contains(&"/python/component1".to_string()));
+        assert!(component_paths.contains(&"/python/component2".to_string()));
     }
 }

--- a/stepflow-rs/crates/stepflow-plugin/src/routing/rules.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing/rules.rs
@@ -14,9 +14,96 @@
 use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize};
 use serde_with::{OneOrMany, serde_as};
-use std::borrow::Cow;
 use stepflow_core::values::ValueRef;
 use stepflow_core::workflow::JsonPath;
+
+/// Enhanced routing target configuration with path transformation and component filtering
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RoutingTarget {
+    /// Plugin name to route to
+    pub plugin: String,
+    
+    /// Path segments to strip from the component path before sending to the plugin
+    pub strip_segments: Vec<String>,
+    
+    /// Include only these components (supports glob patterns)
+    #[serde(default)]
+    pub components: Option<Vec<String>>,
+    
+    /// Exclude these components (supports glob patterns)
+    #[serde(default)]
+    pub exclude_components: Option<Vec<String>>,
+}
+
+/// Target configuration supporting both simple strings and complex targets
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum Target {
+    /// Simple string target for backward compatibility and auto-detection
+    Simple(String),
+    /// Complex target with path transformation and component filtering
+    Complex(RoutingTarget),
+}
+
+impl From<&str> for Target {
+    fn from(s: &str) -> Self {
+        Target::Simple(s.to_string())
+    }
+}
+
+impl From<String> for Target {
+    fn from(s: String) -> Self {
+        Target::Simple(s)
+    }
+}
+
+impl Target {
+    /// Get the plugin name from the target
+    pub fn plugin(&self) -> &str {
+        match self {
+            Target::Simple(plugin) => plugin,
+            Target::Complex(target) => &target.plugin,
+        }
+    }
+    
+    /// Auto-detect strip segments from match pattern for simple targets
+    pub fn with_auto_strip_segments(self, match_pattern: &str) -> Target {
+        match self {
+            Target::Simple(plugin) => {
+                let strip_segments = auto_detect_strip_segments(match_pattern);
+                Target::Complex(RoutingTarget {
+                    plugin,
+                    strip_segments,
+                    components: None,
+                    exclude_components: None,
+                })
+            }
+            Target::Complex(_) => self,
+        }
+    }
+    
+    /// Get the routing target configuration (auto-detects for simple targets)
+    pub fn as_routing_target(&self, match_pattern: &str) -> RoutingTarget {
+        match self {
+            Target::Simple(plugin) => RoutingTarget {
+                plugin: plugin.clone(),
+                strip_segments: auto_detect_strip_segments(match_pattern),
+                components: None,
+                exclude_components: None,
+            },
+            Target::Complex(target) => target.clone(),
+        }
+    }
+}
+
+/// Auto-detect strip segments from match pattern
+/// For simple targets, we default to no strip segments since many plugins
+/// (like builtin plugins) already return full paths with the plugin prefix
+fn auto_detect_strip_segments(_match_pattern: &str) -> Vec<String> {
+    // Default to no strip segments for simple targets
+    // Users can use complex targets if they need path transformation
+    Vec::new()
+}
 
 /// A single routing rule that matches components and routes them to plugins
 #[serde_as]
@@ -28,8 +115,8 @@ pub struct RoutingRule {
     #[serde_as(as = "OneOrMany<_>")]
     pub match_rule: Vec<MatchRule>,
 
-    /// Target plugin name to route to.
-    pub target: Cow<'static, str>,
+    /// Target configuration supporting both simple strings and complex targets
+    pub target: Target,
 }
 
 /// Match rule with JSON path support for precise input matching
@@ -157,7 +244,7 @@ mod tests {
                     component: "/openai/*".to_string(),
                     input: vec![],
                 }],
-                target: "openai".into(),
+                target: Target::Simple("openai".to_string()),
             },
             RoutingRule {
                 match_rule: vec![MatchRule {
@@ -167,7 +254,7 @@ mod tests {
                         value: ValueRef::new(serde_json::json!("gpt-4")),
                     }],
                 }],
-                target: "custom".into(),
+                target: Target::Simple("custom".to_string()),
             },
         ];
 
@@ -203,9 +290,9 @@ mod tests {
         let rules: RoutingRules = serde_json::from_str(json_str).unwrap();
         assert_eq!(rules.len(), 2);
         assert_eq!(rules[0].match_rule[0].component, "/openai/*");
-        assert_eq!(rules[0].target, "openai");
+        assert_eq!(rules[0].target.plugin(), "openai");
         assert_eq!(rules[1].match_rule[0].component, "/custom/*");
-        assert_eq!(rules[1].target, "custom");
+        assert_eq!(rules[1].target.plugin(), "custom");
         assert_eq!(rules[1].match_rule[0].input.len(), 1);
         assert_eq!(
             rules[1].match_rule[0].input[0].value,
@@ -315,7 +402,7 @@ mod tests {
         assert!(routing_rule.match_rule[0].input.is_empty());
         assert_eq!(routing_rule.match_rule[1].component, "/custom/*");
         assert_eq!(routing_rule.match_rule[1].input.len(), 1);
-        assert_eq!(routing_rule.target, "mixed");
+        assert_eq!(routing_rule.target.plugin(), "mixed");
     }
 
     #[test]
@@ -330,7 +417,7 @@ mod tests {
         let routing_rule: RoutingRule = serde_json::from_str(json_str).unwrap();
         assert_eq!(routing_rule.match_rule.len(), 1);
         assert_eq!(routing_rule.match_rule[0].component, "/openai/*");
-        assert_eq!(routing_rule.target, "openai");
+        assert_eq!(routing_rule.target.plugin(), "openai");
     }
 
     #[test]
@@ -406,7 +493,7 @@ mod tests {
                     component: "/openai/*".to_string(),
                     input: vec![],
                 }],
-                target: "openai".into(),
+                target: Target::Simple("openai".to_string()),
             },
             RoutingRule {
                 match_rule: vec![
@@ -422,7 +509,7 @@ mod tests {
                         input: vec![],
                     },
                 ],
-                target: "custom".into(),
+                target: Target::Simple("custom".to_string()),
             },
         ];
 
@@ -434,7 +521,7 @@ mod tests {
             original[0].match_rule[0].component,
             deserialized[0].match_rule[0].component
         );
-        assert_eq!(original[0].target, deserialized[0].target);
+        assert_eq!(original[0].target.plugin(), deserialized[0].target.plugin());
         assert_eq!(
             original[1].match_rule.len(),
             deserialized[1].match_rule.len()
@@ -447,5 +534,93 @@ mod tests {
             original[1].match_rule[0].input[0].value,
             deserialized[1].match_rule[0].input[0].value
         );
+    }
+
+    #[test]
+    fn test_auto_detect_strip_segments() {
+        // Auto-detection now defaults to no strip segments for better compatibility
+        assert_eq!(auto_detect_strip_segments("/python/*"), Vec::<String>::new());
+        assert_eq!(auto_detect_strip_segments("/ai/python/*"), Vec::<String>::new());
+        assert_eq!(auto_detect_strip_segments("/custom/analysis/advanced/*"), Vec::<String>::new());
+        assert_eq!(auto_detect_strip_segments("*"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_target_plugin_method() {
+        let simple_target = Target::Simple("openai".to_string());
+        assert_eq!(simple_target.plugin(), "openai");
+
+        let complex_target = Target::Complex(RoutingTarget {
+            plugin: "custom".to_string(),
+            strip_segments: vec!["ai".to_string()],
+            components: None,
+            exclude_components: None,
+        });
+        assert_eq!(complex_target.plugin(), "custom");
+    }
+
+    #[test]
+    fn test_target_as_routing_target() {
+        let simple_target = Target::Simple("python".to_string());
+        let routing_target = simple_target.as_routing_target("/python/*");
+        
+        assert_eq!(routing_target.plugin, "python");
+        assert_eq!(routing_target.strip_segments, Vec::<String>::new());
+        assert_eq!(routing_target.components, None);
+        assert_eq!(routing_target.exclude_components, None);
+    }
+
+    #[test]
+    fn test_complex_target_serialization() {
+        let rule = RoutingRule {
+            match_rule: vec![MatchRule {
+                component: "/python/*".to_string(),
+                input: vec![],
+            }],
+            target: Target::Complex(RoutingTarget {
+                plugin: "python".to_string(),
+                strip_segments: vec!["python".to_string()],
+                components: Some(vec!["udf".to_string(), "analyzer".to_string()]),
+                exclude_components: Some(vec!["debug_*".to_string()]),
+            }),
+        };
+
+        let serialized = serde_json::to_string(&rule).unwrap();
+        let deserialized: RoutingRule = serde_json::from_str(&serialized).unwrap();
+        
+        assert_eq!(deserialized.target.plugin(), "python");
+        if let Target::Complex(target) = deserialized.target {
+            assert_eq!(target.strip_segments, vec!["python"]);
+            assert_eq!(target.components, Some(vec!["udf".to_string(), "analyzer".to_string()]));
+            assert_eq!(target.exclude_components, Some(vec!["debug_*".to_string()]));
+        } else {
+            panic!("Expected complex target");
+        }
+    }
+
+    #[test]
+    fn test_complex_target_deserialization() {
+        let json_str = r#"
+        {
+            "match": "/python/*",
+            "target": {
+                "plugin": "python",
+                "strip_segments": ["python"],
+                "components": ["udf", "analyzer"],
+                "exclude_components": ["debug_*"]
+            }
+        }
+        "#;
+
+        let rule: RoutingRule = serde_json::from_str(json_str).unwrap();
+        assert_eq!(rule.target.plugin(), "python");
+        
+        if let Target::Complex(target) = rule.target {
+            assert_eq!(target.strip_segments, vec!["python"]);
+            assert_eq!(target.components, Some(vec!["udf".to_string(), "analyzer".to_string()]));
+            assert_eq!(target.exclude_components, Some(vec!["debug_*".to_string()]));
+        } else {
+            panic!("Expected complex target");
+        }
     }
 }

--- a/stepflow-rs/crates/stepflow-plugin/src/routing/transform.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing/transform.rs
@@ -1,0 +1,314 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+// See the NOTICE file distributed with this work for additional information regarding copyright
+// ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the License.  You may obtain a
+// copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations under
+// the License.
+
+use error_stack::{Result, ResultExt};
+use globset::Glob;
+use stepflow_core::workflow::Component;
+use crate::error::PluginError;
+use crate::routing::rules::RoutingTarget;
+
+/// Component filter for include/exclude pattern matching
+#[derive(Debug, Clone)]
+pub struct ComponentFilter {
+    include_patterns: Vec<Glob>,
+    exclude_patterns: Vec<Glob>,
+}
+
+impl ComponentFilter {
+    /// Create a new component filter from a routing target
+    pub fn from_target(target: &RoutingTarget) -> Result<Self, PluginError> {
+        let mut include_patterns = Vec::new();
+        let mut exclude_patterns = Vec::new();
+        
+        // Parse include patterns
+        if let Some(components) = &target.components {
+            for pattern_str in components {
+                let pattern = Glob::new(pattern_str)
+                    .change_context(PluginError::Configuration)?;
+                include_patterns.push(pattern);
+            }
+        }
+        
+        // Parse exclude patterns
+        if let Some(exclude_components) = &target.exclude_components {
+            for pattern_str in exclude_components {
+                let pattern = Glob::new(pattern_str)
+                    .change_context(PluginError::Configuration)?;
+                exclude_patterns.push(pattern);
+            }
+        }
+        
+        Ok(ComponentFilter {
+            include_patterns,
+            exclude_patterns,
+        })
+    }
+    
+    /// Create a filter that matches all components
+    pub fn allow_all() -> Self {
+        ComponentFilter {
+            include_patterns: Vec::new(),
+            exclude_patterns: Vec::new(),
+        }
+    }
+    
+    /// Check if a component name matches this filter
+    pub fn matches(&self, component_name: &str) -> bool {
+        // If include patterns are specified, component must match at least one
+        if !self.include_patterns.is_empty() {
+            let included = self.include_patterns.iter().any(|p| p.compile_matcher().is_match(component_name));
+            if !included {
+                return false;
+            }
+        }
+        
+        // Component must not match any exclude patterns
+        !self.exclude_patterns.iter().any(|p| p.compile_matcher().is_match(component_name))
+    }
+    
+    /// Check if a component matches this filter
+    pub fn matches_component(&self, component: &Component) -> bool {
+        // For filtering, we want to match against the component name part
+        // For builtin components, use the builtin name
+        // For path-based components, the component name is the final path segment
+        let component_name = if component.is_builtin() {
+            component.builtin_name().unwrap_or("")
+        } else {
+            // Extract component name from path like "/udf" -> "udf" or "/nested/path" -> "path"
+            let path = component.path_string();
+            let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+            if let Some(last_part) = parts.last() {
+                last_part
+            } else {
+                ""
+            }
+        };
+        self.matches(component_name)
+    }
+}
+
+/// Path transformer for bidirectional path transformation
+#[derive(Debug, Clone)]
+pub struct PathTransformer {
+    strip_segments: Vec<String>,
+}
+
+impl PathTransformer {
+    /// Create a new path transformer
+    pub fn new(strip_segments: Vec<String>) -> Self {
+        PathTransformer { strip_segments }
+    }
+    
+    /// Create a path transformer from a routing target
+    pub fn from_target(target: &RoutingTarget) -> Self {
+        PathTransformer::new(target.strip_segments.clone())
+    }
+    
+    /// Transform a path from routing format to plugin format (forward transformation)
+    /// Example: "/python/udf" with strip_segments ["python"] -> "/udf"
+    pub fn transform_to_plugin(&self, original_path: &str) -> Result<String, PluginError> {
+        let mut segments = original_path.split('/').filter(|s| !s.is_empty()).collect::<Vec<_>>();
+        
+        // Validate that the path starts with the expected segments
+        if segments.len() < self.strip_segments.len() {
+            return Err(error_stack::report!(PluginError::Configuration)
+                .attach_printable(format!(
+                    "Path '{}' has fewer segments than expected strip_segments {:?}",
+                    original_path, self.strip_segments
+                )));
+        }
+        
+        // Validate each segment matches
+        for (i, expected) in self.strip_segments.iter().enumerate() {
+            if segments.get(i) != Some(&expected.as_str()) {
+                return Err(error_stack::report!(PluginError::Configuration)
+                    .attach_printable(format!(
+                        "Path '{}' segment {} is '{}' but expected '{}' based on strip_segments {:?}",
+                        original_path, i, segments.get(i).map_or("", |v| v), expected, self.strip_segments
+                    )));
+            }
+        }
+        
+        // Remove the stripped segments
+        segments.drain(0..self.strip_segments.len());
+        
+        // Return the transformed path
+        if segments.is_empty() {
+            Ok("/".to_string())
+        } else {
+            Ok(format!("/{}", segments.join("/")))
+        }
+    }
+    
+    /// Transform a path from plugin format to routing format (reverse transformation)
+    /// Example: "/udf" with strip_segments ["python"] -> "/python/udf"
+    pub fn transform_from_plugin(&self, plugin_path: &str) -> String {
+        let plugin_segments = plugin_path.split('/').filter(|s| !s.is_empty()).collect::<Vec<_>>();
+        let mut full_path = self.strip_segments.clone();
+        full_path.extend(plugin_segments.iter().map(|s| s.to_string()));
+        
+        if full_path.is_empty() {
+            "/".to_string()
+        } else {
+            format!("/{}", full_path.join("/"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routing::rules::RoutingTarget;
+
+    #[test]
+    fn test_component_filter_allow_all() {
+        let filter = ComponentFilter::allow_all();
+        assert!(filter.matches("udf"));
+        assert!(filter.matches("analyzer"));
+        assert!(filter.matches("debug_tool"));
+    }
+
+    #[test]
+    fn test_component_filter_include_patterns() {
+        let target = RoutingTarget {
+            plugin: "python".to_string(),
+            strip_segments: vec!["python".to_string()],
+            components: Some(vec!["udf".to_string(), "analyzer".to_string()]),
+            exclude_components: None,
+        };
+        
+        let filter = ComponentFilter::from_target(&target).unwrap();
+        assert!(filter.matches("udf"));
+        assert!(filter.matches("analyzer"));
+        assert!(!filter.matches("debug_tool"));
+    }
+
+    #[test]
+    fn test_component_filter_exclude_patterns() {
+        let target = RoutingTarget {
+            plugin: "python".to_string(),
+            strip_segments: vec!["python".to_string()],
+            components: None,
+            exclude_components: Some(vec!["debug_*".to_string()]),
+        };
+        
+        let filter = ComponentFilter::from_target(&target).unwrap();
+        assert!(filter.matches("udf"));
+        assert!(filter.matches("analyzer"));
+        assert!(!filter.matches("debug_tool"));
+        assert!(!filter.matches("debug_analyzer"));
+    }
+
+    #[test]
+    fn test_component_filter_include_and_exclude() {
+        let target = RoutingTarget {
+            plugin: "python".to_string(),
+            strip_segments: vec!["python".to_string()],
+            components: Some(vec!["ml_*".to_string(), "data_*".to_string()]),
+            exclude_components: Some(vec!["*_debug".to_string()]),
+        };
+        
+        let filter = ComponentFilter::from_target(&target).unwrap();
+        assert!(filter.matches("ml_classifier"));
+        assert!(filter.matches("data_processor"));
+        assert!(!filter.matches("ml_classifier_debug"));
+        assert!(!filter.matches("data_processor_debug"));
+        assert!(!filter.matches("other_tool"));
+    }
+
+    #[test]
+    fn test_path_transformer_single_segment() {
+        let transformer = PathTransformer::new(vec!["python".to_string()]);
+        
+        // Forward transformation
+        assert_eq!(transformer.transform_to_plugin("/python/udf").unwrap(), "/udf");
+        assert_eq!(transformer.transform_to_plugin("/python/analyzer").unwrap(), "/analyzer");
+        assert_eq!(transformer.transform_to_plugin("/python/deep/nested/path").unwrap(), "/deep/nested/path");
+        
+        // Reverse transformation
+        assert_eq!(transformer.transform_from_plugin("/udf"), "/python/udf");
+        assert_eq!(transformer.transform_from_plugin("/analyzer"), "/python/analyzer");
+        assert_eq!(transformer.transform_from_plugin("/deep/nested/path"), "/python/deep/nested/path");
+    }
+
+    #[test]
+    fn test_path_transformer_multiple_segments() {
+        let transformer = PathTransformer::new(vec!["ai".to_string(), "python".to_string()]);
+        
+        // Forward transformation
+        assert_eq!(transformer.transform_to_plugin("/ai/python/udf").unwrap(), "/udf");
+        assert_eq!(transformer.transform_to_plugin("/ai/python/analyzer").unwrap(), "/analyzer");
+        
+        // Reverse transformation
+        assert_eq!(transformer.transform_from_plugin("/udf"), "/ai/python/udf");
+        assert_eq!(transformer.transform_from_plugin("/analyzer"), "/ai/python/analyzer");
+    }
+
+    #[test]
+    fn test_path_transformer_validation_error() {
+        let transformer = PathTransformer::new(vec!["python".to_string()]);
+        
+        // Wrong prefix should fail
+        assert!(transformer.transform_to_plugin("/openai/udf").is_err());
+        
+        // Path with only plugin name should result in root path
+        assert_eq!(transformer.transform_to_plugin("/python").unwrap(), "/");
+        
+        // Empty path should fail
+        assert!(transformer.transform_to_plugin("").is_err());
+    }
+
+    #[test]
+    fn test_path_transformer_from_target() {
+        let target = RoutingTarget {
+            plugin: "python".to_string(),
+            strip_segments: vec!["ai".to_string(), "python".to_string()],
+            components: None,
+            exclude_components: None,
+        };
+        
+        let transformer = PathTransformer::from_target(&target);
+        assert_eq!(transformer.transform_to_plugin("/ai/python/udf").unwrap(), "/udf");
+        assert_eq!(transformer.transform_from_plugin("/udf"), "/ai/python/udf");
+    }
+
+    #[test]
+    fn test_path_transformer_root_path() {
+        let transformer = PathTransformer::new(vec!["python".to_string()]);
+        
+        // When plugin returns root path, should still work
+        assert_eq!(transformer.transform_from_plugin("/"), "/python");
+        
+        // When stripping results in empty path, should return root
+        assert_eq!(transformer.transform_to_plugin("/python").unwrap(), "/");
+    }
+
+    #[test]
+    fn test_component_filter_with_component_struct() {
+        let target = RoutingTarget {
+            plugin: "python".to_string(),
+            strip_segments: vec!["python".to_string()],
+            components: Some(vec!["udf".to_string()]),
+            exclude_components: None,
+        };
+        
+        let filter = ComponentFilter::from_target(&target).unwrap();
+        
+        // Test with plugin-stripped paths (what the plugin would return)
+        let component_udf = Component::from_string("/udf");
+        let component_analyzer = Component::from_string("/analyzer");
+        
+        assert!(filter.matches_component(&component_udf));
+        assert!(!filter.matches_component(&component_analyzer));
+    }
+}

--- a/stepflow-rs/tests/routing/README.md
+++ b/stepflow-rs/tests/routing/README.md
@@ -1,0 +1,123 @@
+# Routing Tests
+
+This directory contains comprehensive tests and examples for the StepFlow routing system, demonstrating path transformation and component filtering capabilities.
+
+## Configuration Overview
+
+The `stepflow-config.yml` file demonstrates advanced routing features:
+
+### Complex Routing with Component Filtering
+```yaml
+- match: "/python/*"
+  target:
+    plugin: python
+    strip_segments: []  # No transformation needed
+    components: ["udf"]  # Only allow udf component
+    exclude_components: ["debug_*"]  # Exclude debug tools
+```
+
+This configuration:
+- **Matches** components that start with `/python/`
+- **No path transformation** since the Python plugin returns correctly prefixed paths
+- **Filters components** to only allow `udf` component
+- **Excludes** any components matching the `debug_*` pattern
+
+### Simple Routing
+```yaml
+- match: "/builtin/*"
+  target: builtin
+```
+
+This provides direct access to builtin components without transformation.
+
+## Test Files
+
+### `path_transformation.yaml`
+Demonstrates how routing works with component filtering:
+
+- **User writes**: `/python/udf` in the workflow
+- **System routes**: Directly to the Python plugin (no transformation needed)
+- **Plugin receives**: `/udf` (the component it actually implements)
+
+The workflow shows:
+1. Data processing using `/python/udf`
+2. Analysis using `/python/udf` (reused for demo purposes)
+3. Final message generation using builtin `create_messages`
+
+### `component_filtering.yaml`
+Shows how component filtering works:
+
+- **Allowed components**: Only `udf` is accessible through the `/python/*` route
+- **Blocked components**: Any component matching `debug_*` pattern would be filtered out
+- **Test case**: Uses `/python/udf` for text processing
+
+## Key Features Demonstrated
+
+### 1. Component Filtering
+- Include specific components: `components: ["udf"]`
+- Exclude patterns: `exclude_components: ["debug_*"]`
+- Provides security and organization benefits
+
+### 2. Multiple Route Support
+- Same plugin can have multiple routing rules
+- Different filtering for different routes
+- Flexible access control
+
+### 3. Path Transformation (Advanced)
+- Strip segments for plugins that return unprefixed paths
+- Configurable with `strip_segments: ["segment1", "segment2"]`
+- Useful for organizing component namespaces
+
+### 4. Backward Compatibility
+- Simple string targets still work: `target: builtin`
+- Complex targets provide advanced features
+- Gradual migration path
+
+## Running the Tests
+
+```bash
+# Run the path transformation test
+cargo run -- run --flow=tests/routing/path_transformation.yaml --input='{"numbers": [1,2,3,4,5], "message": "test"}' --config=tests/routing/stepflow-config.yml
+
+# Run the component filtering test  
+cargo run -- run --flow=tests/routing/component_filtering.yaml --input='{"text": "Hello World", "operation": "uppercase"}' --config=tests/routing/stepflow-config.yml
+
+# List available components to see the routing in action
+cargo run -- list-components --config=tests/routing/stepflow-config.yml
+```
+
+## Expected Component Listing
+
+With the routing configuration, `list-components` should show:
+
+```
+Available Components:
+====================
+
+Component: /python/udf
+  Description: Execute user-defined function (UDF) using cached compiled functions from blobs
+
+Component: /builtin/create_messages
+  Description: Create a chat message list from system instructions and user prompt
+
+Component: /builtin/eval
+  Description: Execute a nested workflow with given input and return the result
+
+Component: /builtin/get_blob
+  Description: Retrieve JSON data from a blob using its ID
+
+Component: /builtin/load_file
+  Description: Load and parse a file (JSON, YAML, or text) from the filesystem
+
+Component: /builtin/openai
+  Description: Send messages to OpenAI's chat completion API and get a response
+
+Component: /builtin/put_blob
+  Description: Store JSON data as a blob and return its content-addressable ID
+```
+
+Note how:
+- Python components appear as `/python/udf` (only the allowed component)
+- No debug components are shown (filtered out by `exclude_components`)
+- Builtin components are available with `/builtin/` prefix
+- The routing system provides a unified view of all accessible components

--- a/stepflow-rs/tests/routing/advanced_transformation.yaml
+++ b/stepflow-rs/tests/routing/advanced_transformation.yaml
@@ -1,0 +1,67 @@
+## Advanced Path Transformation Example
+
+# This file demonstrates how to configure path transformation for plugins
+# that return unprefixed component paths (not the current Python plugin)
+
+# Example stepflow-config.yml for path transformation:
+# ```yaml
+# plugins:
+#   custom_plugin:
+#     type: stepflow
+#     transport: stdio
+#     command: my-custom-plugin
+#     args: []
+# routing:
+#   - match: "/ai/ml/custom/*"
+#     target:
+#       plugin: custom_plugin
+#       strip_segments: ["ai", "ml", "custom"]
+#       components: ["classifier", "regressor"]
+#       exclude_components: ["debug_*"]
+# ```
+
+# With this configuration:
+# - User writes:    /ai/ml/custom/classifier
+# - System strips:  /ai/ml/custom/classifier → /classifier
+# - Plugin receives: /classifier
+# - Plugin returns:  /classifier (unprefixed path)
+# - System adds back: /classifier → /ai/ml/custom/classifier (for display)
+
+# This is useful for:
+# 1. Organizing components into logical namespaces
+# 2. Keeping plugin implementations simple (no path prefixing needed)
+# 3. Providing consistent component naming across different plugins
+# 4. Controlling access to specific components via filtering
+
+# Example workflow using path transformation:
+input_schema:
+  type: object
+  properties:
+    data:
+      type: array
+      items:
+        type: number
+output_schema:
+  type: object
+  properties:
+    classification:
+      type: string
+steps:
+# This would use the custom plugin with path transformation
+- id: classify_data
+  component: /ai/ml/custom/classifier
+  input_schema: null
+  output_schema: null
+  input:
+    data:
+      $from:
+        workflow: input
+      path: data
+output:
+  classification:
+    $from:
+      step: classify_data
+    path: result
+
+# Note: This example is for illustration only and won't run
+# since the custom plugin doesn't exist in the current setup

--- a/stepflow-rs/tests/routing/component_filtering.yaml
+++ b/stepflow-rs/tests/routing/component_filtering.yaml
@@ -1,0 +1,126 @@
+input_schema:
+  type: object
+  properties:
+    text:
+      type: string
+    operation:
+      type: string
+      enum: ["uppercase", "lowercase", "reverse"]
+output_schema:
+  type: object
+  properties:
+    original_text:
+      type: string
+    transformed_text:
+      type: string
+    operation_used:
+      type: string
+steps:
+# Create text processing function as a blob
+- id: create_text_processor_blob
+  component: put_blob
+  input_schema: null
+  output_schema: null
+  input:
+    data:
+      input_schema:
+        type: object
+        properties:
+          text:
+            type: string
+          operation:
+            type: string
+        required:
+        - text
+        - operation
+      code: |
+        text = input['text']
+        operation = input['operation']
+        
+        if operation == 'uppercase':
+          result = text.upper()
+        elif operation == 'lowercase':
+          result = text.lower()
+        elif operation == 'reverse':
+          result = text[::-1]
+        else:
+          result = text
+        
+        return {
+          'original': text,
+          'transformed': result,
+          'operation': operation
+        }
+
+# Process text using the /python/udf component
+# Note: This component is allowed by the "components" filter in stepflow-config.yml
+- id: process_text
+  component: /python/udf
+  input_schema: null
+  output_schema: null
+  input:
+    blob_id:
+      $from:
+        step: create_text_processor_blob
+      path: blob_id
+    input:
+      text:
+        $from:
+          workflow: input
+        path: text
+      operation:
+        $from:
+          workflow: input
+        path: operation
+
+# Note: If we tried to use /python/debug_tool, it would be filtered out
+# by the "exclude_components" filter in stepflow-config.yml and would fail
+
+output:
+  original_text:
+    $from:
+      step: process_text
+    path: original
+  transformed_text:
+    $from:
+      step: process_text
+    path: transformed
+  operation_used:
+    $from:
+      step: process_text
+    path: operation
+
+test:
+  cases:
+  - name: uppercase transformation
+    input:
+      text: "Hello World"
+      operation: "uppercase"
+    output:
+      outcome: success
+      result:
+        original_text: "Hello World"
+        transformed_text: "HELLO WORLD"
+        operation_used: "uppercase"
+  
+  - name: lowercase transformation
+    input:
+      text: "Hello World"
+      operation: "lowercase"
+    output:
+      outcome: success
+      result:
+        original_text: "Hello World"
+        transformed_text: "hello world"
+        operation_used: "lowercase"
+  
+  - name: reverse transformation
+    input:
+      text: "Hello World"
+      operation: "reverse"
+    output:
+      outcome: success
+      result:
+        original_text: "Hello World"
+        transformed_text: "dlroW olleH"
+        operation_used: "reverse"

--- a/stepflow-rs/tests/routing/path_transformation.yaml
+++ b/stepflow-rs/tests/routing/path_transformation.yaml
@@ -1,0 +1,185 @@
+input_schema:
+  type: object
+  properties:
+    numbers:
+      type: array
+      items:
+        type: number
+    message:
+      type: string
+output_schema:
+  type: object
+  properties:
+    processed_data:
+      type: object
+    analysis_result:
+      type: object
+    final_message:
+      type: string
+steps:
+# Store processing function as a blob
+- id: create_processor_blob
+  component: put_blob
+  input_schema: null
+  output_schema: null
+  input:
+    data:
+      input_schema:
+        type: object
+        properties:
+          numbers:
+            type: array
+            items:
+              type: number
+        required:
+        - numbers
+      code: |
+        import statistics
+        numbers = input['numbers']
+        return {
+          'sum': sum(numbers),
+          'mean': statistics.mean(numbers),
+          'count': len(numbers),
+          'max': max(numbers),
+          'min': min(numbers)
+        }
+
+# Store analysis function as a blob
+- id: create_analyzer_blob
+  component: put_blob
+  input_schema: null
+  output_schema: null
+  input:
+    data:
+      input_schema:
+        type: object
+        properties:
+          processed_data:
+            type: object
+          message:
+            type: string
+        required:
+        - processed_data
+        - message
+      code: |
+        data = input['processed_data']
+        message = input['message']
+        
+        # Analyze the processed data
+        analysis = {
+          'range': data['max'] - data['min'],
+          'is_large_dataset': data['count'] > 5,
+          'above_average': data['sum'] > data['mean'] * data['count'] * 0.8,
+          'analysis_summary': f"Dataset with {data['count']} numbers, mean={data['mean']:.2f}"
+        }
+        
+        return {
+          'analysis': analysis,
+          'enhanced_message': f"{message} - Analysis: {analysis['analysis_summary']}"
+        }
+
+# Process data using the /python/udf component (with component filtering)
+- id: process_numbers
+  component: /python/udf
+  input_schema: null
+  output_schema: null
+  input:
+    blob_id:
+      $from:
+        step: create_processor_blob
+      path: blob_id
+    input:
+      numbers:
+        $from:
+          workflow: input
+        path: numbers
+
+# For demo purposes, let's use the same UDF component for analysis
+# In a real scenario, you would implement an actual analyzer component
+- id: analyze_data
+  component: /python/udf
+  input_schema: null
+  output_schema: null
+  input:
+    blob_id:
+      $from:
+        step: create_analyzer_blob
+      path: blob_id
+    input:
+      processed_data:
+        $from:
+          step: process_numbers
+      message:
+        $from:
+          workflow: input
+        path: message
+
+# Create final message using builtin component
+- id: create_final_message
+  component: create_messages
+  input_schema: null
+  output_schema: null
+  input:
+    system: "You are a data analysis assistant. Provide a concise summary of the analysis results."
+    user:
+      $from:
+        step: analyze_data
+      path: enhanced_message
+
+output:
+  processed_data:
+    $from:
+      step: process_numbers
+  analysis_result:
+    $from:
+      step: analyze_data
+  final_message:
+    $from:
+      step: create_final_message
+    path: content
+
+test:
+  cases:
+  - name: analyze small dataset
+    input:
+      numbers: [1, 2, 3, 4, 5]
+      message: "Small dataset analysis"
+    output:
+      outcome: success
+      result:
+        processed_data:
+          sum: 15
+          mean: 3.0
+          count: 5
+          max: 5
+          min: 1
+        analysis_result:
+          analysis:
+            range: 4
+            is_large_dataset: false
+            above_average: true
+            analysis_summary: "Dataset with 5 numbers, mean=3.00"
+          enhanced_message: "Small dataset analysis - Analysis: Dataset with 5 numbers, mean=3.00"
+        final_message: "Data analysis complete: Small dataset with 5 numbers showing a mean of 3.00, range of 4, and above-average sum distribution."
+  
+  - name: analyze large dataset
+    input:
+      numbers: [10, 20, 30, 40, 50, 60, 70]
+      message: "Large dataset processing"
+    output:
+      outcome: success
+      result:
+        processed_data:
+          sum: 280
+          mean: 40.0
+          count: 7
+          max: 70
+          min: 10
+        analysis_result:
+          analysis:
+            range: 60
+            is_large_dataset: true
+            above_average: true
+            analysis_summary: "Dataset with 7 numbers, mean=40.00"
+          enhanced_message: "Large dataset processing - Analysis: Dataset with 7 numbers, mean=40.00"
+        final_message: "Data analysis complete: Large dataset with 7 numbers showing a mean of 40.00, range of 60, and above-average sum distribution."

--- a/stepflow-rs/tests/routing/simple_filtering.yaml
+++ b/stepflow-rs/tests/routing/simple_filtering.yaml
@@ -1,0 +1,79 @@
+input_schema:
+  type: object
+  properties:
+    text:
+      type: string
+output_schema:
+  type: object
+  properties:
+    processed_text:
+      type: string
+    message_count:
+      type: number
+steps:
+# Create a simple text processing function
+- id: create_text_processor
+  component: put_blob
+  input_schema: null
+  output_schema: null
+  input:
+    data:
+      input_schema:
+        type: object
+        properties:
+          text:
+            type: string
+        required:
+        - text
+      code: |
+        text = input['text']
+        # Simple text processing: uppercase and add exclamation
+        processed = text.upper() + "!"
+        return processed
+
+# Process text using the filtered Python UDF component
+- id: process_text
+  component: /python/udf
+  input_schema: null
+  output_schema: null
+  input:
+    blob_id:
+      $from:
+        step: create_text_processor
+      path: blob_id
+    input:
+      text:
+        $from:
+          workflow: input
+        path: text
+
+# Create a message using builtin component
+- id: create_message
+  component: create_messages
+  input_schema: null
+  output_schema: null
+  input:
+    system: "You are a helpful assistant."
+    user:
+      $from:
+        step: process_text
+
+output:
+  processed_text:
+    $from:
+      step: process_text
+  message_count:
+    $from:
+      step: create_message
+    path: content.length
+
+test:
+  cases:
+  - name: simple text processing
+    input:
+      text: "hello world"
+    output:
+      outcome: success
+      result:
+        processed_text: "HELLO WORLD!"
+        message_count: 5  # Example - actual value depends on create_messages output

--- a/stepflow-rs/tests/routing/stepflow-config.yml
+++ b/stepflow-rs/tests/routing/stepflow-config.yml
@@ -1,0 +1,23 @@
+plugins:
+  builtin:
+    type: builtin
+  python:
+    type: stepflow
+    transport: stdio
+    command: uv
+    args: [--project, "../../../sdks/python", run, stepflow_sdk]
+routing:
+  # Simple routing that works with current Python plugin behavior
+  # The Python plugin returns "/python/udf" so we route "/python/*" directly
+  - match: "/python/*"
+    target:
+      plugin: python
+      strip_segments: [] # No transformation needed since plugin returns correct paths
+      components: ["udf"] # Only allow udf component (no analyzer in current Python SDK)
+      exclude_components: ["debug_*"] # Exclude debug tools
+  # Simple routing for builtin components
+  - match: "/builtin/*"
+    target: builtin
+  # Fallback to builtin for unmatched paths
+  - match: "*"
+    target: builtin


### PR DESCRIPTION
This addresses two related problems:

1. Based on the route, the path to a component may be different. The component servers shouldn't need to be aware of routing to determine their components. The idea here is to allow the routing to update the path to reflect the path *relative the route* to pass to the component server. For instance, a route for `/python/*` can match `/python/bar` and pass `/bar` to the component server.
2. When we need to list all of the components available, we need to consider the routes. This means that if a route filters out some components, they should not be listed. If a route transforms the path to a component, it should be listed with the transformed path. If a route conditionally matches, that information should be displayed.