### PR TITLE
feat: Change to trie-based routing

### DIFF
--- a/docs/docs/components/builtins.md
+++ b/docs/docs/components/builtins.md
@@ -35,7 +35,7 @@ output:
 ```yaml
 steps:
   - id: store_user_data
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         user_id: { $from: { workflow: input }, path: "user_id" }
@@ -70,7 +70,7 @@ output:
 ```yaml
 steps:
   - id: retrieve_user_data
-    component: get_blob
+    component: /builtin/et_blob
     input:
       blob_id: { $from: { step: store_user_data }, path: "blob_id" }
 ```
@@ -124,12 +124,12 @@ output:
 ```yaml
 steps:
   - id: load_config
-    component: load_file
+    component: /builtin/load_file
     input:
       path: "config/settings.yaml"
 
   - id: load_data
-    component: load_file
+    component: /builtin/load_file
     input:
       path: { $from: { workflow: input }, path: "data_file" }
       format: "json"
@@ -170,7 +170,7 @@ output:
 ```yaml
 steps:
   - id: prepare_chat
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: "You are an expert data analyst"
       user_prompt: { $from: { workflow: input }, path: "question" }
@@ -219,7 +219,7 @@ Each message must have:
 ```yaml
 steps:
   - id: ask_ai
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: prepare_chat }, path: "messages" }
       max_tokens: 200
@@ -231,13 +231,13 @@ steps:
 ```yaml
 steps:
   - id: create_prompt
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: "You are a code review assistant. Analyze code for potential issues."
       user_prompt: { $from: { workflow: input }, path: "code_snippet" }
 
   - id: analyze_code
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: create_prompt }, path: "messages" }
       max_tokens: 500
@@ -280,7 +280,7 @@ output:
 ```yaml
 steps:
   - id: run_analysis
-    component: eval
+    component: /builtin/eval
     input:
       workflow:
         input_schema:
@@ -289,11 +289,11 @@ steps:
             data: { type: array }
         steps:
           - id: process
-            component: data/analyze
+            component: /data/analyze
             input:
               data: { $from: { workflow: input }, path: "data" }
           - id: summarize
-            component: data/summarize
+            component: /data/summarize
             input:
               analysis: { $from: { step: process } }
         output:

--- a/docs/docs/components/index.md
+++ b/docs/docs/components/index.md
@@ -111,17 +111,17 @@ Components communicate through structured JSON data:
 ```yaml
 steps:
   - id: load_data
-    component: load_file
+    component: /builtin/load_file
     input:
       path: "data.json"
 
   - id: process
-    component: my_components://analyze_text
+    component: /my_components/analyze_text
     input:
       text: { $from: { step: load_data }, path: "data.content" }
 
   - id: store_result
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data: { $from: { step: process } }
 ```
@@ -170,13 +170,13 @@ Start with StepFlow's built-in components for common tasks:
 name: "AI Analysis Workflow"
 steps:
   - id: prepare_prompt
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: "You are a helpful assistant"
       user_prompt: "Analyze this text for sentiment"
 
   - id: call_ai
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: prepare_prompt }, path: "messages" }
       max_tokens: 150

--- a/docs/docs/examples/ai-workflows.md
+++ b/docs/docs/examples/ai-workflows.md
@@ -36,7 +36,7 @@ input_schema:
 steps:
   # Create personalized system instructions
   - id: create_system_prompt
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -82,14 +82,14 @@ steps:
 
   # Create chat messages
   - id: create_messages
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: { $from: { step: execute_system_prompt } }
       user_prompt: { $from: { workflow: input }, path: "user_question" }
 
   # Get AI response
   - id: get_ai_response
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: create_messages }, path: "messages" }
       max_tokens: 500
@@ -97,7 +97,7 @@ steps:
 
   # Post-process response (add metadata, format, etc.)
   - id: format_response
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -193,13 +193,13 @@ input_schema:
 steps:
   # Load the document
   - id: load_document
-    component: load_file
+    component: /builtin/load_file
     input:
       path: { $from: { workflow: input }, path: "document_path" }
 
   # Extract key information
   - id: extract_key_info
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a document analysis expert. Extract the most important information from documents.
@@ -211,7 +211,7 @@ steps:
         {{ $from: { step: load_document }, path: "data" }}
 
   - id: get_key_info
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: extract_key_info }, path: "messages" }
       max_tokens: 800
@@ -219,7 +219,7 @@ steps:
 
   # Generate summary (runs in parallel with key info extraction)
   - id: create_summary_prompt
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a professional summarization expert. Create clear, concise summaries
@@ -231,7 +231,7 @@ steps:
         {{ $from: { step: load_document }, path: "data" }}
 
   - id: get_summary
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: create_summary_prompt }, path: "messages" }
       max_tokens: 400
@@ -239,7 +239,7 @@ steps:
 
   # Perform sentiment analysis (if requested)
   - id: analyze_sentiment
-    component: create_messages
+    component: /builtin/create_messages
     skip:
       # Skip if sentiment not in focus_areas
       # This would need custom logic to check array membership
@@ -253,7 +253,7 @@ steps:
         {{ $from: { step: load_document }, path: "data" }}
 
   - id: get_sentiment
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: analyze_sentiment }, path: "messages" }
       max_tokens: 300
@@ -261,7 +261,7 @@ steps:
 
   # Generate recommendations (if comprehensive analysis requested)
   - id: generate_recommendations
-    component: create_messages
+    component: /builtin/create_messages
     skip:
       # Skip if not comprehensive analysis
       # This would check if analysis_depth != "comprehensive"
@@ -279,7 +279,7 @@ steps:
         {{ $from: { step: load_document }, path: "data" }}
 
   - id: get_recommendations
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: generate_recommendations }, path: "messages" }
       max_tokens: 600
@@ -287,7 +287,7 @@ steps:
 
   # Combine all analysis results
   - id: combine_analysis
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -400,7 +400,7 @@ input_schema:
 steps:
   # Step 1: Break down the research question
   - id: analyze_question
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a research methodology expert. When given a research question,
@@ -418,7 +418,7 @@ steps:
         4. Suggested research approach
 
   - id: get_question_analysis
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: analyze_question }, path: "messages" }
       max_tokens: 600
@@ -426,7 +426,7 @@ steps:
 
   # Step 2: Load and process context documents
   - id: load_context_docs
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -474,7 +474,7 @@ steps:
 
   # Step 4: First reasoning iteration
   - id: first_reasoning_step
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a research analyst. Based on the research question breakdown and
@@ -490,7 +490,7 @@ steps:
         Please provide your initial analysis and identify what additional information is needed.
 
   - id: get_first_reasoning
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: first_reasoning_step }, path: "messages" }
       max_tokens: 800
@@ -498,7 +498,7 @@ steps:
 
   # Step 5: Second reasoning iteration (deeper analysis)
   - id: second_reasoning_step
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a senior research analyst. Building on previous analysis,
@@ -514,7 +514,7 @@ steps:
         4. Areas of uncertainty
 
   - id: get_second_reasoning
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: second_reasoning_step }, path: "messages" }
       max_tokens: 800
@@ -522,7 +522,7 @@ steps:
 
   # Step 6: Generate final research synthesis
   - id: final_synthesis
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a research director. Synthesize all previous analysis into a
@@ -545,7 +545,7 @@ steps:
         5. Suggested next research steps
 
   - id: get_final_synthesis
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: final_synthesis }, path: "messages" }
       max_tokens: 1200
@@ -553,7 +553,7 @@ steps:
 
   # Step 7: Create structured research report
   - id: create_research_report
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -673,7 +673,7 @@ input_schema:
 steps:
   # Generate initial content outline
   - id: create_outline
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a content strategist and expert writer. Create detailed outlines
@@ -692,7 +692,7 @@ steps:
         Provide a structured outline with main sections, subsections, and brief descriptions.
 
   - id: get_outline
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: create_outline }, path: "messages" }
       max_tokens: 600
@@ -700,7 +700,7 @@ steps:
 
   # Generate full content based on outline
   - id: generate_content
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are an expert content writer. Write engaging, well-structured content
@@ -719,7 +719,7 @@ steps:
         Make it engaging, informative, and well-structured.
 
   - id: get_initial_content
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: generate_content }, path: "messages" }
       max_tokens: 1500
@@ -727,7 +727,7 @@ steps:
 
   # Review content for accuracy and structure
   - id: review_content
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a content editor and quality assurance expert. Review content
@@ -747,7 +747,7 @@ steps:
         Provide specific suggestions for improvement.
 
   - id: get_content_review
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: review_content }, path: "messages" }
       max_tokens: 800
@@ -755,7 +755,7 @@ steps:
 
   # Refine content based on review
   - id: refine_content
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: |
         You are a senior content editor. Refine and improve content based on
@@ -772,7 +772,7 @@ steps:
         Provide the improved version of the content.
 
   - id: get_refined_content
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: refine_content }, path: "messages" }
       max_tokens: 1500
@@ -780,7 +780,7 @@ steps:
 
   # Generate final content package
   - id: create_content_package
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:

--- a/docs/docs/examples/data-processing.md
+++ b/docs/docs/examples/data-processing.md
@@ -123,7 +123,7 @@ steps:
 
   # Create data quality report
   - id: create_quality_report
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -192,7 +192,7 @@ steps:
 
   # Transform and enrich sales data
   - id: transform_sales_data
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -273,7 +273,7 @@ steps:
 
   # Prepare data for loading
   - id: prepare_warehouse_load
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -334,7 +334,7 @@ steps:
 
   # Create final ETL report
   - id: create_etl_report
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -471,7 +471,7 @@ steps:
 
   # Parse and validate incoming events
   - id: parse_events
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -540,7 +540,7 @@ steps:
 
   # Real-time analytics and aggregation
   - id: calculate_real_time_metrics
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -713,7 +713,7 @@ input_schema:
 steps:
   # Profile each dataset in parallel
   - id: profile_dataset_1
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -765,7 +765,7 @@ steps:
 
   # Apply quality rules to dataset
   - id: apply_quality_rules
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -872,7 +872,7 @@ steps:
 
   # Generate quality dashboard data
   - id: generate_dashboard_data
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:

--- a/docs/docs/examples/mcp-tools.md
+++ b/docs/docs/examples/mcp-tools.md
@@ -125,7 +125,7 @@ steps:
 
   # Generate index file
   - name: create_index
-    component: template
+    component: /builtin/template
     inputs:
       template: |
         # Document Index
@@ -212,7 +212,7 @@ MCP tools can return two types of errors:
      continueOnError: true
 
    - name: use_default
-     component: template
+     component: /builtin/template
      when: ${{ steps.read_config.failed }}
      inputs:
        template: '{"default": true}'
@@ -261,7 +261,7 @@ Use `continueOnError` and conditional steps for graceful error handling:
 
 - name: fallback
   when: ${{ steps.try_operation.failed }}
-  component: log
+  component: /builtin/log
   inputs:
     message: "Operation failed, using fallback"
 ```
@@ -296,7 +296,7 @@ Use `continueOnError` and conditional steps for graceful error handling:
 ```yaml
 steps:
   - name: select_operation
-    component: template
+    component: /builtin/template
     inputs:
       template: "${{ inputs.operation_type }}://{{ inputs.tool_name }}"
 

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -73,7 +73,7 @@ output_schema:
 steps:
   # Store the context as a blob for potential reuse
   - id: store_context
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         context: { $from: { workflow: input }, path: "context" }
@@ -81,7 +81,7 @@ steps:
 
     # Format the context and question into a clear prompt
   - id: format_prompt
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         context: { $from: { workflow: input }, path: "context" }
@@ -89,20 +89,20 @@ steps:
 
   # Get the formatted prompt from the blob
   - id: get_prompt
-    component: get_blob
+    component: /builtin/get_blob
     input:
       blob_id: { $from: { step: format_prompt }, path: "blob_id" }
 
   # Create messages for OpenAI
   - id: create_messages
-    component: create_messages
+    component: /builtin/create_messages
     input:
       system_instructions: "You are a helpful assistant. Answer the user's question based on the provided context. If the context doesn't contain enough information, say so and provide your best general answer."
       user_prompt: { $from: { step: get_prompt }, path: "$.data.question" }
 
-  # Generate AI response using OpenAI  
+  # Generate AI response using OpenAI
   - id: generate_answer
-    component: openai
+    component: /builtin/openai
     input:
       messages: { $from: { step: create_messages }, path: "messages" }
       temperature: 0.3
@@ -110,7 +110,7 @@ steps:
 
   # Create response metadata
   - id: create_metadata
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         processed_at: "2024-01-15T10:30:00Z"
@@ -226,7 +226,7 @@ Now that you've run your first RAG workflow, explore these topics to build more 
 
 ### Workflow Development
 * **[Workflow Fundamentals](./workflows/steps.md)** - Understanding steps, execution order, and dependencies
-* **[Input & Output](./workflows/input_output.md)** - Data flow patterns and schema validation  
+* **[Input & Output](./workflows/input_output.md)** - Data flow patterns and schema validation
 * **[Expression System](./workflows/expressions.md)** - Advanced data references and transformations
 * **[Testing](./workflows/testing.md)** - Comprehensive testing patterns and CI/CD integration
 * **[Workflow Specification](./workflows/specification.md)** - Complete workflow file format reference

--- a/docs/docs/workflows/control-flow.md
+++ b/docs/docs/workflows/control-flow.md
@@ -31,7 +31,7 @@ Steps can be conditionally skipped using the `skip` field:
 ```yaml
 steps:
   - id: expensive_analysis
-    component: ai/analyze
+    component: /ai/analyze
     skip: { $from: { workflow: input }, path: is_premium_user }
     input:
       data: { $from: { step: previous_step } }
@@ -51,7 +51,7 @@ This propagation can be interrupted by configuring how an input should be comput
 ```yaml
 steps:
   - id: consumer_step
-    component: data/process
+    component: /data/process
     input:
       required_data: { $from: { step: step1 } }
       optional_enhancement:
@@ -73,7 +73,7 @@ Steps can handle their own failures using the `on_error` field:
 ```yaml
 steps:
   - id: risky_operation
-    component: external/api_call
+    component: /external/api_call
     on_error:
       action: continue
       default_output:
@@ -101,18 +101,19 @@ Sub-workflows can be executed using the built-in `eval` component:
 ```yaml
 steps:
   - id: sub_process
-    component: eval
+    component: /builtin/eval
     input:
       workflow:
-        inputs:
-          data: { type: string }
-        steps:
-          - id: process
-            component: data/transform
-            input:
-              input: { $from: { workflow: input }, path: data }
-        output:
-          result: { $from: { step: process } }
+        $literal:
+          inputs:
+            data: { type: string }
+          steps:
+            - id: process
+              component: /data/transform
+              input:
+                input: { $from: { workflow: input }, path: data }
+          output:
+            result: { $from: { step: process } }
       input:
         data: { $from: { step: previous_step }, path: processed_data }
 ```

--- a/docs/docs/workflows/specification.md
+++ b/docs/docs/workflows/specification.md
@@ -192,7 +192,7 @@ output_schema:
 ```yaml
 steps:
   - id: unique_step_identifier
-    component: component_name
+    component: /path/component_name
     input:
       param1: { $from: { workflow: input }, path: "field" }
       param2: { $literal: "static_value" }
@@ -497,7 +497,7 @@ Examples serve multiple purposes:
 ```yaml
 steps:
   - id: check_environment
-    component: environment_check
+    component: /env/environment_check
     input:
       environment: { $from: { workflow: input }, path: "env" }
 
@@ -565,14 +565,14 @@ imports:
 steps:
   # Use imported workflow as a step
   - id: validate_input
-    component: eval
+    component: /builtin/eval
     input:
       workflow: { $import: "validate" }
       input: { $from: { workflow: input } }
 
   # Chain workflows
   - id: process_text
-    component: eval
+    component: /builtin/eval
     input:
       workflow: { $import: "text_proc" }
       input: { $from: { step: validate_input } }

--- a/docs/docs/workflows/steps.md
+++ b/docs/docs/workflows/steps.md
@@ -13,7 +13,7 @@ A step has the following structure:
 ```yaml
 steps:
   - id: step_name
-    component: component_url
+    component: /path/component
     input:
       # Input data for the component
     # Optional fields:
@@ -47,7 +47,7 @@ Steps execute based on their dependencies, not their order in the YAML file. Ste
 steps:
   # This step runs first (no dependencies)
   - id: load_data
-    component: load_file
+    component: /builtin/load_file
     input:
       path: "data.json"
 
@@ -59,13 +59,13 @@ steps:
 
   # This step also waits for load_data (runs in parallel with process_data)
   - id: validate_data
-    component: validate
+    component: /validate
     input:
       data: { $from: { step: load_data } }
 
   # This step waits for both process_data and validate_data
   - id: combine_results
-    component: merge
+    component: /merge
     input:
       processed: { $from: { step: process_data } }
       validated: { $from: { step: validate_data } }
@@ -124,7 +124,7 @@ input:
 ```yaml
 steps:
   - id: expensive_analysis
-    component: ai/analyze
+    component: /ai/analyze
     skip: { $from: { workflow: input }, path: "skip_analysis" }
     input:
       data: { $from: { step: load_data } }
@@ -137,12 +137,12 @@ When a step is skipped, consuming steps are also skipped by default:
 ```yaml
 steps:
   - id: optional_step
-    component: data/process
+    component: /data/process
     skip: { $from: { workflow: input }, path: "skip_optional" }
 
   # This step is skipped if optional_step is skipped
   - id: dependent_step
-    component: data/analyze
+    component: /data/analyze
     input:
       data: { $from: { step: optional_step } }
 ```
@@ -154,7 +154,7 @@ Use `$on_skip` to provide default values when dependencies are skipped:
 ```yaml
 steps:
   - id: consumer_step
-    component: data/process
+    component: /data/process
     input:
       required_data: { $from: { step: required_step } }
       optional_data:
@@ -175,7 +175,7 @@ steps:
 ```yaml
 steps:
   - id: risky_operation
-    component: external/api_call
+    component: /external/api_call
     on_error:
       action: continue        # continue|skip|terminate
       default_output:
@@ -205,13 +205,13 @@ When using `action: continue`, the `default_output` must:
 ```yaml
 # Blob storage
 - id: store_data
-  component: put_blob
+  component: /builtin/put_blob
   input:
     data: { $from: { step: prepare_data } }
 
 # Sub-workflow execution
 - id: sub_process
-  component: eval
+  component: /builtin/eval
   input:
     workflow: { $from: { step: load_workflow } }
     input: { $from: { step: prepare_input } }
@@ -229,7 +229,7 @@ When using `action: continue`, the `default_output` must:
 
 # Custom component server
 - id: specialized_task
-  component: my_plugin://advanced_processor
+  component: /my_plugin/advanced_processor
   input:
     configuration: { $from: { step: load_config } }
     data: { $from: { step: prepare_data } }
@@ -240,7 +240,7 @@ When using `action: continue`, the `default_output` must:
 ```yaml
 # OpenAI API call
 - id: ai_analysis
-  component: openai
+  component: /builtin/openai
   input:
     messages:
       - role: system
@@ -276,7 +276,7 @@ steps:
 ```yaml
 steps:
   - id: process_if_large
-    component: data/heavy_processor
+    component: /data/heavy_processor
     skip:
       $from: { step: check_size }
       path: "is_small"
@@ -284,7 +284,7 @@ steps:
       data: { $from: { step: load_data } }
 
   - id: process_if_small
-    component: data/light_processor
+    component: /data/light_processor
     skip:
       $from: { step: check_size }
       path: "is_large"
@@ -297,7 +297,7 @@ steps:
 ```yaml
 steps:
   - id: final_step
-    component: data/combine
+    component: /data/combine
     input:
       # Wait for multiple steps
       processed: { $from: { step: process_data } }
@@ -364,12 +364,12 @@ input:
 ```yaml
 # Critical operation - must succeed
 - id: authenticate_user
-  component: auth/verify
+  component: /auth/verify
   # on_error defaults to terminate
 
 # Optional enhancement - can fail gracefully
 - id: enrich_profile
-  component: data/enrich
+  component: /data/enrich
   on_error:
     action: continue
     default_output:
@@ -378,7 +378,7 @@ input:
 
 # Completely optional - skip if fails
 - id: log_analytics
-  component: analytics/track
+  component: /analytics/track
   on_error:
     action: skip
 ```

--- a/examples/basic/stepflow-config.yml
+++ b/examples/basic/stepflow-config.yml
@@ -6,8 +6,8 @@ plugins:
     transport: stdio
     command: uv
     args: ["--project", "../../sdks/python", "run", "stepflow_sdk"]
-routing:
-  - match: "/python/*"
-    target: python
-  - match: "*"
-    target: builtin
+routes:
+  "/builtin/{*component}":
+    - plugin: builtin
+  "/python/{*component}":
+    - plugin: python

--- a/examples/basic/workflow.yaml
+++ b/examples/basic/workflow.yaml
@@ -27,7 +27,7 @@ output_schema:
 steps:
   # Create UDF for addition
   - id: create_addition_udf
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -38,9 +38,9 @@ steps:
           required: [a, b]
         code: "input['a'] + input['b']"
 
-  # Create UDF for multiplication  
+  # Create UDF for multiplication
   - id: create_multiplication_udf
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:

--- a/examples/custom-python-components/workflow.yaml
+++ b/examples/custom-python-components/workflow.yaml
@@ -40,7 +40,7 @@ steps:
       report_title: "Q4 Customer Analysis Report"
 
   - id: retrieve_report
-    component: "get_blob"
+    component: "/builtin/get_blob"
     input:
       blob_id: { $from: { step: generate_business_report }, path: "report_blob_id" }
 

--- a/examples/data-pipeline/debug-pipeline.yaml
+++ b/examples/data-pipeline/debug-pipeline.yaml
@@ -14,7 +14,7 @@ input_schema:
 steps:
   # Parallel data processing steps
   - id: sum_revenue_udf
-    component: "put_blob"
+    component: "/builtin/put_blob"
     input:
       data:
         $literal:
@@ -28,7 +28,7 @@ steps:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: count_sales_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -42,7 +42,7 @@ steps:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: average_sale_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -56,7 +56,7 @@ steps:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: divide_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -72,29 +72,29 @@ steps:
 
   # Format metrics summary for display
   - id: format_metrics_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
           code: |
             performance_status = "✅ EXCEEDED TARGET" if input['performance_ratio'] > 1.0 else "⚠️ BELOW TARGET"
             f"""Sales Performance Analysis:
-            
+
             📊 Key Metrics:
             • Total Revenue: ${input['total_revenue']:,.2f}
             • Sales Count: {input['sales_count']} transactions
             • Average Sale Value: ${input['average_sale']:,.2f}
             • Target Revenue: ${input['target_revenue']:,.2f}
             • Performance vs Target: {input['performance_ratio']:.1%}
-            
+
             🎯 Performance Status: {performance_status}
-            
+
             Please analyze this sales data and provide:
             1. Key insights about our sales performance
             2. What the metrics reveal about our business
             3. Specific recommendations for improving sales
             4. Any concerning trends or positive highlights
-            
+
             Focus on actionable business insights that would help a sales manager make strategic decisions."""
 
   - id: format_metrics_summary

--- a/examples/data-pipeline/pipeline.yaml
+++ b/examples/data-pipeline/pipeline.yaml
@@ -14,7 +14,7 @@ input_schema:
 steps:
   # Parallel data processing steps
   - id: sum_revenue_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -28,7 +28,7 @@ steps:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: count_sales_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -42,7 +42,7 @@ steps:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: average_sale_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -57,7 +57,7 @@ steps:
 
   # This step waits for total_revenue to complete
   - id: divide_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -73,14 +73,14 @@ steps:
 
   # Regional analysis using eval components (run in parallel)
   - id: analyze_west_region
-    component: "eval"
+    component: /builtin/eval
     input:
       workflow:
         $literal:
           name: "West Region Analysis"
           steps:
             - id: filter_west_udf
-              component: "put_blob"
+              component: /builtin/put_blob
               input:
                 data:
                   $literal:
@@ -94,7 +94,7 @@ steps:
                   sales_data: { $from: { workflow: input }, path: "sales_data" }
 
             - id: west_revenue_udf
-              component: "put_blob"
+              component: /builtin/put_blob
               input:
                 data:
                   $literal:
@@ -108,7 +108,7 @@ steps:
                   filtered_data: { $from: { step: filter_region }, path: "result" }
 
             - id: west_count_udf
-              component: "put_blob"
+              component: /builtin/put_blob
               input:
                 data:
                   $literal:
@@ -129,14 +129,14 @@ steps:
         sales_data: { $from: { workflow: input }, path: "sales_data" }
 
   - id: analyze_east_region
-    component: "eval"
+    component: /builtin/eval
     input:
       workflow:
         $literal:
           name: "East Region Analysis"
           steps:
             - id: filter_east_udf
-              component: "put_blob"
+              component: /builtin/put_blob
               input:
                 data:
                   $literal:
@@ -150,7 +150,7 @@ steps:
                   sales_data: { $from: { workflow: input }, path: "sales_data" }
 
             - id: east_revenue_udf
-              component: "put_blob"
+              component: /builtin/put_blob
               input:
                 data:
                   $literal:
@@ -164,7 +164,7 @@ steps:
                   filtered_data: { $from: { step: filter_region }, path: "result" }
 
             - id: east_count_udf
-              component: "put_blob"
+              component: /builtin/put_blob
               input:
                 data:
                   $literal:
@@ -186,7 +186,7 @@ steps:
 
   # Compare regional performance
   - id: compare_regions_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -216,25 +216,25 @@ steps:
 
   # Format metrics for AI analysis (waits for all calculations)
   - id: format_metrics_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
           code: |
             f"""Sales Analysis Summary:
-            
+
             Overall Metrics:
             - Total Revenue: ${input['total_revenue']:,.2f}
             - Number of Sales: {input['sales_count']}
             - Average Sale Value: ${input['average_sale']:,.2f}
             - Performance vs Target: {input['performance_ratio']:.1%} (Target: ${input['target_revenue']:,.2f})
-            
+
             Regional Performance:
             - West Region: ${input['regional_comparison']['west_revenue']:,.2f} ({input['regional_comparison']['west_count']} sales)
             - East Region: ${input['regional_comparison']['east_revenue']:,.2f} ({input['regional_comparison']['east_count']} sales)
             - Revenue Leader: {input['regional_comparison']['revenue_leader']} (${input['regional_comparison']['revenue_difference']:,.2f} difference)
             - Volume Leader: {input['regional_comparison']['count_leader']} ({input['regional_comparison']['count_difference']} sales difference)
-            
+
             Please provide strategic insights and recommendations based on this data."""
 
   - id: format_metrics_summary
@@ -251,14 +251,14 @@ steps:
 
   # Format messages for OpenAI (depends on metrics summary)
   - id: create_openai_messages
-    component: "create_messages"
+    component: /builtin/create_messages
     input:
       system_instructions: "You are a senior sales analyst providing insights based on business metrics and regional performance. Be specific and actionable in your recommendations."
       user_prompt: { $from: { step: format_metrics_summary }, path: "summary" }
 
   # Generate AI insights from the comprehensive metrics
   - id: generate_ai_insights
-    component: "openai"
+    component: /builtin/openai
     input:
       messages: { $from: { step: create_openai_messages }, path: "messages" }
 

--- a/examples/eval/README.md
+++ b/examples/eval/README.md
@@ -156,7 +156,7 @@ The examples have been updated to use the correct workflow syntax:
 ```yaml
 steps:
   - id: my_eval_step
-    component: "eval"
+    component: /builtin/eval
     input:  # Not 'args'
       workflow:
         $literal:  # Required for inline workflow definitions
@@ -199,7 +199,7 @@ Once you've verified the basic examples work, you can use eval components for:
 ### Regional Analysis Pattern
 ```yaml
 - id: analyze_region
-  component: "eval"
+  component: /builtin/eval
   input:
     workflow:
       $literal:
@@ -225,7 +225,7 @@ Once you've verified the basic examples work, you can use eval components for:
 ### Dynamic Workflow Generation
 ```yaml
 - id: process_all_regions
-  component: "eval"
+  component: /builtin/eval
   input:
     workflow: { $from: { step: generate_region_workflow }, path: "workflow_def" }
     input: { $from: { step: prepare_region_data }, path: "data" }

--- a/examples/eval/math-eval.yaml
+++ b/examples/eval/math-eval.yaml
@@ -9,14 +9,14 @@ input_schema:
 
 steps:
   - id: nested_math
-    component: "eval"
+    component: /builtin/eval
     input:
       workflow:
         $literal:
           name: "Nested Math Workflow"
           steps:
             - id: add_udf
-              component: "put_blob"
+              component: /builtin/put_blob
               input:
                 data:
                   $literal:
@@ -27,7 +27,7 @@ steps:
                         b: { type: integer }
                       required: [a, b]
                     code: "input['a'] + input['b']"
-            
+
             - id: compute_sum
               component: "/python/udf"
               input:

--- a/examples/eval/simple-eval.yaml
+++ b/examples/eval/simple-eval.yaml
@@ -3,7 +3,7 @@ description: "Basic test of the eval builtin component"
 
 steps:
   - id: test_eval
-    component: "eval"
+    component: /builtin/eval
     input:
       workflow:
         $literal:

--- a/examples/eval/stepflow-config.yml
+++ b/examples/eval/stepflow-config.yml
@@ -6,8 +6,8 @@ plugins:
     transport: stdio
     command: uv
     args: ["--project", "../../sdks/python", "run", "stepflow_sdk"]
-routing:
-  - match: "/python/*"
-    target: python
-  - match: "*"
-    target: builtin
+routes:
+  "/builtin/{*component}":
+    - plugin: builtin
+  "/python/{*component}":
+    - plugin: python

--- a/examples/eval/test-builtins.yaml
+++ b/examples/eval/test-builtins.yaml
@@ -2,7 +2,7 @@ name: "Test Builtins Registry"
 
 steps:
   - id: test_create_messages
-    component: "create_messages"
+    component: /builtin/create_messages
     input:
       system_instructions: "You are a test assistant"
       user_prompt: "Say hello"

--- a/examples/file-loading/load-pipeline.yaml
+++ b/examples/file-loading/load-pipeline.yaml
@@ -14,13 +14,13 @@ input_schema:
 steps:
   # Load the sales data from file
   - id: load_sales_data
-    component: "load_file"
+    component: /builtin/load_file
     input:
       path: { $from: { workflow: input }, path: "data_file_path" }
 
   # Extract the sales_data array using UDF
   - id: extract_sales_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -35,7 +35,7 @@ steps:
 
   # Now process the sales data array
   - id: sum_revenue_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -49,7 +49,7 @@ steps:
         sales_data: { $from: { step: "extract_sales_array" }, path: "result" }
 
   - id: count_sales_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -63,7 +63,7 @@ steps:
         sales_data: { $from: { step: "extract_sales_array" }, path: "result" }
 
   - id: average_sale_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:
@@ -77,7 +77,7 @@ steps:
         sales_data: { $from: { step: "extract_sales_array" }, path: "result" }
 
   - id: divide_udf
-    component: "put_blob"
+    component: /builtin/put_blob
     input:
       data:
         $literal:

--- a/examples/file-loading/stepflow-config.yml
+++ b/examples/file-loading/stepflow-config.yml
@@ -6,8 +6,8 @@ plugins:
     args: ["--project", "../../sdks/python", "run", "stepflow_sdk"]
   builtin:
     type: builtin
-routing:
-  - match: "/python/*"
-    target: python
-  - match: "*"
-    target: builtin
+routes:
+  "/builtin/{*component}":
+    - plugin: builtin
+  "/python/{*component}":
+    - plugin: python

--- a/examples/file-loading/test-load.yaml
+++ b/examples/file-loading/test-load.yaml
@@ -3,7 +3,7 @@ description: "Simple test of the load_file component"
 
 steps:
   - id: load_sales_data
-    component: "load_file"
+    component: /builtin/load_file
     input:
       path: "test-data.json"
 

--- a/examples/loop-components/stepflow-config.yml
+++ b/examples/loop-components/stepflow-config.yml
@@ -7,8 +7,8 @@ plugins:
     command: uv
     args: ["--project", "../../sdks/python", "run", "python", "loop_server.py"]
 
-routing:
-  - match: "/python/*"
-    target: python
-  - match: "*"
-    target: builtin
+routes:
+  "/builtin/{*component}":
+    - plugin: builtin
+  "/python/{*component}":
+    - plugin: python

--- a/examples/openai/openai_chat.yaml
+++ b/examples/openai/openai_chat.yaml
@@ -12,13 +12,13 @@ inputs:
 
 steps:
   - id: create_messages
-    component: "create_messages"
+    component: /builtin/create_messages
     input:
       system_instructions: { $from: { workflow: input }, path: system_message }
       user_prompt: { $from: { workflow: input }, path: prompt }
 
   - id: send_message
-    component: "openai"
+    component: /builtin/openai
     input:
       messages: { $from: { step: create_messages }, path: messages }
 

--- a/schemas/protocol.json
+++ b/schemas/protocol.json
@@ -139,7 +139,7 @@
       "description": "Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf').",
       "type": "string",
       "examples": [
-        "eval",
+        "/builtin/eval",
         "/mcpfs/list_files",
         "/python/udf"
       ]

--- a/sdks/python/src/stepflow_sdk/generated_protocol.py
+++ b/sdks/python/src/stepflow_sdk/generated_protocol.py
@@ -68,7 +68,7 @@ Component = Annotated[
     str,
     Meta(
         description="Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf').",
-        examples=['eval', '/mcpfs/list_files', '/python/udf'],
+        examples=['/builtin/eval', '/mcpfs/list_files', '/python/udf'],
     ),
 ]
 

--- a/sdks/python/src/stepflow_sdk/http_server.py
+++ b/sdks/python/src/stepflow_sdk/http_server.py
@@ -280,10 +280,9 @@ class StepflowHttpServer:
 
         component_infos = []
         for name, component in session.server.get_components().items():
-            component_url = f"/{session.server.get_protocol_prefix()}/{name}"
             component_infos.append(
                 ComponentInfo(
-                    component=component_url,
+                    component=name,
                     input_schema=component.input_schema(),
                     output_schema=component.output_schema(),
                     description=component.description,
@@ -299,12 +298,10 @@ class StepflowHttpServer:
             # Auto-initialize for HTTP mode
             session.server.set_initialized(True)
 
-        component_name = params.component.split("/")[-1]
-        components = session.server.get_components()
-        if component_name not in components:
-            raise ComponentNotFoundError(f"Component '{component_name}' not found")
+        component = session.server.get_components().get(params.component)
+        if component is None:
+            raise ComponentNotFoundError(f"Component '{params.component}' not found")
 
-        component = components[component_name]
         info = ComponentInfo(
             component=params.component,
             input_schema=component.input_schema(),
@@ -321,12 +318,9 @@ class StepflowHttpServer:
             # Auto-initialize for HTTP mode
             session.server.set_initialized(True)
 
-        component_name = params.component.split("/")[-1]
-        components = session.server.get_components()
-        if component_name not in components:
-            raise ComponentNotFoundError(f"Component '{component_name}' not found")
-
-        component = components[component_name]
+        component = session.server.get_components().get(params.component)
+        if component is None:
+            raise ComponentNotFoundError(f"Component '{params.component}' not found")
 
         try:
             # The input is already a dictionary (JSON object)

--- a/sdks/python/tests/test_http_server.py
+++ b/sdks/python/tests/test_http_server.py
@@ -85,7 +85,7 @@ class TestSessionIsolation:
             id=same_request_id,
             method=Method.components_execute,
             params=ComponentExecuteParams(
-                component="/python/test_component",
+                component="/test_component",
                 input={"message": "Session 1 message"},
             ),
         )
@@ -100,7 +100,7 @@ class TestSessionIsolation:
             id=same_request_id,
             method=Method.components_execute,
             params=ComponentExecuteParams(
-                component="/python/test_component",
+                component="/test_component",
                 input={"message": "Session 2 message"},
             ),
         )
@@ -183,7 +183,7 @@ class TestSessionIsolation:
             "method": Method.components_execute,
             "id": same_request_id,
             "params": {
-                "component": "/python/test_component",
+                "component": "/test_component",
                 "input": {"message": "Concurrent message 1"},
             },
         }
@@ -193,7 +193,7 @@ class TestSessionIsolation:
             "method": Method.components_execute,
             "id": same_request_id,
             "params": {
-                "component": "/python/test_component",
+                "component": "/test_component",
                 "input": {"message": "Concurrent message 2"},
             },
         }
@@ -283,7 +283,7 @@ class TestSessionIsolation:
                 "method": Method.components_execute,
                 "id": shared_request_id,
                 "params": {
-                    "component": "/python/test_component",
+                    "component": "/test_component",
                     "input": {"message": f"Message from session {i + 1}"},
                 },
             }
@@ -419,7 +419,7 @@ class TestSessionIsolation:
             "method": Method.components_execute,
             "id": same_request_id,
             "params": {
-                "component": "/python/test_component",
+                "component": "/test_component",
                 "input": {"message": "Success message 1"},
             },
         }
@@ -429,7 +429,7 @@ class TestSessionIsolation:
             "method": Method.components_execute,
             "id": same_request_id,
             "params": {
-                "component": "/python/test_component",
+                "component": "/test_component",
                 "input": {"message": "Success message 2"},
             },
         }
@@ -503,7 +503,7 @@ class TestSessionIsolation:
                 "method": Method.components_execute,
                 "id": same_request_id,
                 "params": {
-                    "component": "/python/test_component",
+                    "component": "/test_component",
                     "input": {"message": f"Rapid message {i} for {session_id}"},
                 },
             }
@@ -570,7 +570,7 @@ class TestSessionIsolation:
             "method": Method.components_execute,
             "id": same_request_id,
             "params": {
-                "component": "/python/test_component",
+                "component": "/test_component",
                 "input": {"message": "Valid request"},
             },
         }

--- a/sdks/python/tests/test_server.py
+++ b/sdks/python/tests/test_server.py
@@ -71,10 +71,10 @@ def test_component_registration(server):
             greeting=f"Hello {input_data.name}!", age_next_year=input_data.age + 1
         )
 
-    assert "test_component" in server._server.get_components()
-    component = server.get_component("/python/test_component")
+    assert "/test_component" in server._server.get_components()
+    component = server.get_component("/test_component")
     assert isinstance(component, ComponentEntry)
-    assert component.name == "test_component"
+    assert component.name == "/test_component"
     assert component.input_type == ValidInput
     assert component.output_type == ValidOutput
 
@@ -86,10 +86,10 @@ def test_component_with_custom_name(server):
             greeting=f"Hello {input_data.name}!", age_next_year=input_data.age + 1
         )
 
-    assert "custom_name" in server._server.get_components()
-    component = server.get_component("/python/custom_name")
+    assert "/custom_name" in server._server.get_components()
+    component = server.get_component("/custom_name")
     assert isinstance(component, ComponentEntry)
-    assert component.name == "custom_name"
+    assert component.name == "/custom_name"
     assert component.input_type == ValidInput
     assert component.output_type == ValidOutput
 
@@ -101,7 +101,7 @@ def test_component_execution(server):
             greeting=f"Hello {input_data.name}!", age_next_year=input_data.age + 1
         )
 
-    component = server.get_component("/python/test_component")
+    component = server.get_component("/test_component")
     assert component is not None
     result = component.function(ValidInput(name="Alice", age=25))
     assert isinstance(result, ValidOutput)
@@ -120,8 +120,8 @@ def test_list_components(server):
 
     components = server._server.get_components()
     assert len(components) == 2
-    assert "component1" in components
-    assert "component2" in components
+    assert "/component1" in components
+    assert "/component2" in components
 
     for name, component in components.items():
         assert isinstance(component, ComponentEntry)
@@ -166,7 +166,7 @@ async def test_handle_component_info(server):
     request = MethodRequest(
         id=str(UUID(int=1)),
         method=Method.components_info,
-        params=ComponentInfoParams(component="/python/test_component"),
+        params=ComponentInfoParams(component="/test_component"),
     )
     response = await server._handle_message(request)
     assert response.id == request.id
@@ -204,7 +204,7 @@ async def test_handle_component_execute(server):
         id=str(UUID(int=1)),
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="/python/test_component", input={"name": "Alice", "age": 25}
+            component="/test_component", input={"name": "Alice", "age": 25}
         ),
     )
     response = await server._handle_message(request)
@@ -226,7 +226,7 @@ async def test_handle_component_execute_invalid_input(server):
         id=str(UUID(int=1)),
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="/python/test_component", input={"invalid": "input"}
+            component="/test_component", input={"invalid": "input"}
         ),
     )
 
@@ -254,8 +254,8 @@ async def test_handle_list_components(server):
     assert response.id == request.id
     assert len(response.result.components) == 2
     component_urls = [comp.component for comp in response.result.components]
-    assert "/python/component1" in component_urls
-    assert "/python/component2" in component_urls
+    assert "/component1" in component_urls
+    assert "/component2" in component_urls
 
 
 @pytest.mark.asyncio
@@ -299,7 +299,7 @@ async def test_server_responses_include_jsonrpc(server):
         id="jsonrpc-test",
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="/python/test_component", input={"name": "Test", "age": 30}
+            component="/test_component", input={"name": "Test", "age": 30}
         ),
     )
 

--- a/stepflow-rs/Cargo.lock
+++ b/stepflow-rs/Cargo.lock
@@ -571,41 +571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -1066,7 +1030,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1384,12 +1348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,17 +1366,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2619,25 +2566,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
 dependencies = [
  "chrono",
  "dyn-clone",
- "indexmap 2.10.0",
+ "indexmap",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -2735,7 +2670,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2765,44 +2700,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.10.0",
- "schemars 0.9.0",
- "schemars 1.0.3",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2983,7 +2886,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.4",
  "hashlink",
- "indexmap 2.10.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -3164,8 +3067,8 @@ version = "0.1.0"
 dependencies = [
  "bit-set",
  "error-stack",
- "indexmap 2.10.0",
- "schemars 1.0.3",
+ "indexmap",
+ "schemars",
  "serde",
  "serde_json",
  "stepflow-core",
@@ -3181,7 +3084,7 @@ dependencies = [
  "error-stack",
  "futures",
  "openai-api-rs",
- "schemars 1.0.3",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -3203,7 +3106,7 @@ version = "0.1.0"
 dependencies = [
  "error-stack",
  "futures",
- "indexmap 2.10.0",
+ "indexmap",
  "rust-mcp-schema",
  "serde",
  "serde_json",
@@ -3223,10 +3126,10 @@ dependencies = [
  "async-trait",
  "error-stack",
  "hex",
- "indexmap 2.10.0",
+ "indexmap",
  "insta",
  "safer_owning_ref",
- "schemars 1.0.3",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -3267,7 +3170,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "error-stack",
- "indexmap 2.10.0",
+ "indexmap",
  "insta-cmd",
  "regex",
  "reqwest",
@@ -3316,13 +3219,15 @@ dependencies = [
  "dynosaur",
  "error-stack",
  "futures",
- "globset",
+ "indexmap",
+ "matchit",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_yaml_ng",
  "stepflow-core",
  "stepflow-state",
  "thiserror 2.0.12",
+ "tracing",
  "trait-variant",
  "uuid",
 ]
@@ -3334,10 +3239,10 @@ dependencies = [
  "erased-serde",
  "error-stack",
  "futures",
- "indexmap 2.10.0",
+ "indexmap",
  "reqwest",
  "reqwest-eventsource",
- "schemars 1.0.3",
+ "schemars",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -3360,7 +3265,7 @@ dependencies = [
  "axum",
  "chrono",
  "error-stack",
- "indexmap 2.10.0",
+ "indexmap",
  "serde",
  "serde_json",
  "stepflow-analysis",
@@ -3776,7 +3681,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -4062,7 +3967,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -4875,7 +4780,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.10.0",
+ "indexmap",
  "memchr",
  "zopfli",
 ]

--- a/stepflow-rs/Cargo.toml
+++ b/stepflow-rs/Cargo.toml
@@ -21,7 +21,7 @@ erased-serde = "0.4.6"
 error-stack = { version = "0.5.0", features = ["serde"] }
 futures = "0.3.31"
 glob = "0.3"
-globset = "0.4"
+matchit = "0.8.4"
 hex = "0.4"
 indexmap = { version = "2.8.0", features = ["serde"] }
 insta = { version = "1.34.0", features = ["glob", "yaml" ] }

--- a/stepflow-rs/crates/stepflow-analysis/src/diagnostics.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/diagnostics.rs
@@ -11,6 +11,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
+use std::borrow::Cow;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -83,10 +85,10 @@ pub enum DiagnosticMessage {
         reason: String,
     },
     #[serde(rename_all = "camelCase")]
-    InvalidComponentUrl {
+    InvalidComponent {
         step_id: String,
-        url: String,
-        error: String,
+        component: String,
+        error: Cow<'static, str>,
     },
     #[serde(rename_all = "camelCase")]
     EmptyComponentName { step_id: String },
@@ -130,7 +132,7 @@ impl DiagnosticMessage {
 
             // Error diagnostics
             DiagnosticMessage::InvalidFieldAccess { .. } => DiagnosticLevel::Error,
-            DiagnosticMessage::InvalidComponentUrl { .. } => DiagnosticLevel::Error,
+            DiagnosticMessage::InvalidComponent { .. } => DiagnosticLevel::Error,
             DiagnosticMessage::EmptyComponentName { .. } => DiagnosticLevel::Error,
             DiagnosticMessage::SchemaViolation { .. } => DiagnosticLevel::Error,
 
@@ -185,12 +187,12 @@ impl DiagnosticMessage {
             } => {
                 format!("Invalid field access '{field}' on step '{step_id}': {reason}")
             }
-            DiagnosticMessage::InvalidComponentUrl {
+            DiagnosticMessage::InvalidComponent {
                 step_id,
-                url,
+                component,
                 error,
             } => {
-                format!("Invalid component URL '{url}' in step '{step_id}': {error}")
+                format!("Invalid component '{component}' in step '{step_id}': {error}")
             }
             DiagnosticMessage::EmptyComponentName { step_id } => {
                 format!("Empty component name in step '{step_id}'")
@@ -235,7 +237,7 @@ impl DiagnosticMessage {
             DiagnosticMessage::UndefinedStepReference { from_step, .. } => from_step.as_deref(),
             DiagnosticMessage::InvalidReferenceExpression { step_id, .. } => step_id.as_deref(),
             DiagnosticMessage::InvalidFieldAccess { step_id, .. } => Some(step_id),
-            DiagnosticMessage::InvalidComponentUrl { step_id, .. } => Some(step_id),
+            DiagnosticMessage::InvalidComponent { step_id, .. } => Some(step_id),
             DiagnosticMessage::EmptyComponentName { step_id } => Some(step_id),
             DiagnosticMessage::SchemaViolation { step_id, .. } => Some(step_id),
             DiagnosticMessage::MockComponent { step_id } => Some(step_id),

--- a/stepflow-rs/crates/stepflow-builtins/src/blob.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/blob.rs
@@ -51,12 +51,12 @@ struct PutBlobOutput {
 }
 
 impl BuiltinComponent for PutBlobComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<PutBlobInput>();
         let output_schema = SchemaRef::for_type::<PutBlobOutput>();
 
         Ok(ComponentInfo {
-            component: Component::for_plugin(plugin, "put_blob"),
+            component: Component::from_string("/put_blob"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some(
@@ -123,12 +123,12 @@ struct GetBlobOutput {
 }
 
 impl BuiltinComponent for GetBlobComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<GetBlobInput>();
         let output_schema = SchemaRef::for_type::<GetBlobOutput>();
 
         Ok(ComponentInfo {
-            component: Component::for_plugin(plugin, "get_blob"),
+            component: Component::from_string("/get_blob"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some("Retrieve JSON data from a blob using its ID".to_string()),

--- a/stepflow-rs/crates/stepflow-builtins/src/eval.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/eval.rs
@@ -66,12 +66,12 @@ struct EvalOutput {
 }
 
 impl BuiltinComponent for EvalComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<EvalInput>();
         let output_schema = SchemaRef::for_type::<EvalOutput>();
 
         Ok(ComponentInfo {
-            component: Component::for_plugin(plugin, "eval"),
+            component: Component::from_string("/eval"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some(

--- a/stepflow-rs/crates/stepflow-builtins/src/iterate.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/iterate.rs
@@ -71,12 +71,12 @@ struct IterateOutput {
 }
 
 impl BuiltinComponent for IterateComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<IterateInput>();
         let output_schema = SchemaRef::for_type::<IterateOutput>();
 
         Ok(ComponentInfo {
-            component: stepflow_core::workflow::Component::for_plugin(plugin, "iterate"),
+            component: stepflow_core::workflow::Component::from_string("/iterate"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some(

--- a/stepflow-rs/crates/stepflow-builtins/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/lib.rs
@@ -33,7 +33,7 @@ pub use plugin::{BuiltinPluginConfig, Builtins};
 #[trait_variant::make(Send)]
 #[dynosaur::dynosaur(DynBuiltinComponent = dyn BuiltinComponent)]
 pub(crate) trait BuiltinComponent: Send + Sync {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo>;
+    fn component_info(&self) -> Result<ComponentInfo>;
 
     async fn execute(&self, context: ExecutionContext, input: ValueRef) -> Result<FlowResult>;
 }

--- a/stepflow-rs/crates/stepflow-builtins/src/load_file.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/load_file.rs
@@ -90,12 +90,12 @@ impl LoadFileComponent {
 }
 
 impl BuiltinComponent for LoadFileComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<LoadFileInput>();
         let output_schema = SchemaRef::for_type::<LoadFileOutput>();
 
         Ok(ComponentInfo {
-            component: Component::for_plugin(plugin, "load_file"),
+            component: Component::from_string("/load_file"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some(

--- a/stepflow-rs/crates/stepflow-builtins/src/map.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/map.rs
@@ -63,12 +63,12 @@ struct MapOutput {
 }
 
 impl BuiltinComponent for MapComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<MapInput>();
         let output_schema = SchemaRef::for_type::<MapOutput>();
 
         Ok(ComponentInfo {
-            component: stepflow_core::workflow::Component::for_plugin(plugin, "map"),
+            component: stepflow_core::workflow::Component::from_string("/map"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some(

--- a/stepflow-rs/crates/stepflow-builtins/src/messages.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/messages.rs
@@ -40,12 +40,12 @@ struct CreateMessagesOutput {
 }
 
 impl BuiltinComponent for CreateMessagesComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<CreateMessagesInput>();
         let output_schema = SchemaRef::for_type::<CreateMessagesOutput>();
 
         Ok(ComponentInfo {
-            component: Component::for_plugin(plugin, "create_messages"),
+            component: Component::from_string("/create_messages"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some(

--- a/stepflow-rs/crates/stepflow-builtins/src/openai.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/openai.rs
@@ -88,12 +88,12 @@ struct OpenAIOutput {
 }
 
 impl BuiltinComponent for OpenAIComponent {
-    fn component_info(&self, plugin: &str) -> Result<ComponentInfo> {
+    fn component_info(&self) -> Result<ComponentInfo> {
         let input_schema = SchemaRef::for_type::<OpenAIInput>();
         let output_schema = SchemaRef::for_type::<OpenAIOutput>();
 
         Ok(ComponentInfo {
-            component: Component::for_plugin(plugin, "openai"),
+            component: Component::from_string("/openai"),
             input_schema: Some(input_schema),
             output_schema: Some(output_schema),
             description: Some(

--- a/stepflow-rs/crates/stepflow-builtins/src/plugin.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/plugin.rs
@@ -27,9 +27,7 @@ use stepflow_plugin::{
 
 /// The struct that implements the `Plugin` trait.
 #[derive(Default)]
-pub struct Builtins {
-    plugin: String,
-}
+pub struct Builtins;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BuiltinPluginConfig;
@@ -40,16 +38,16 @@ impl PluginConfig for BuiltinPluginConfig {
     async fn create_plugin(
         self,
         _working_directory: &std::path::Path,
-        protocol_prefix: &str,
+        _protocol_prefix: &str,
     ) -> error_stack::Result<Box<DynPlugin<'static>>, Self::Error> {
-        Ok(DynPlugin::boxed(Builtins::new(protocol_prefix.to_owned())))
+        Ok(DynPlugin::boxed(Builtins::new()))
     }
 }
 
 impl Builtins {
     /// Create a new instance with default components registered
-    pub fn new(plugin: String) -> Self {
-        Self { plugin }
+    pub fn new() -> Self {
+        Self
     }
 }
 
@@ -62,7 +60,7 @@ impl Plugin for Builtins {
         // TODO: Cache?
         registry::components()
             .map(|c| {
-                c.component_info(&self.plugin)
+                c.component_info()
                     .change_context(PluginError::ComponentInfo)
             })
             .collect()
@@ -71,7 +69,7 @@ impl Plugin for Builtins {
     async fn component_info(&self, component: &Component) -> Result<ComponentInfo> {
         let component = registry::get_component(component)?;
         component
-            .component_info(&self.plugin)
+            .component_info()
             .change_context(PluginError::ComponentInfo)
     }
 

--- a/stepflow-rs/crates/stepflow-builtins/src/registry.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/registry.rs
@@ -44,24 +44,21 @@ impl Registry {
 
 static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
     let mut registry = Registry::default();
-    registry.register("openai", OpenAIComponent::new("gpt-3.5-turbo"));
-    registry.register("create_messages", CreateMessagesComponent);
-    registry.register("eval", EvalComponent::new());
-    registry.register("iterate", IterateComponent::new());
-    registry.register("load_file", LoadFileComponent);
-    registry.register("map", MapComponent::new());
-    registry.register("put_blob", PutBlobComponent::new());
-    registry.register("get_blob", GetBlobComponent::new());
+    registry.register("/openai", OpenAIComponent::new("gpt-3.5-turbo"));
+    registry.register("/create_messages", CreateMessagesComponent);
+    registry.register("/eval", EvalComponent::new());
+    registry.register("/iterate", IterateComponent::new());
+    registry.register("/load_file", LoadFileComponent);
+    registry.register("/map", MapComponent::new());
+    registry.register("/put_blob", PutBlobComponent::new());
+    registry.register("/get_blob", GetBlobComponent::new());
     registry
 });
 
 pub fn get_component(component: &Component) -> Result<Arc<DynBuiltinComponent<'_>>> {
-    let name = component
-        .builtin_name()
-        .ok_or(PluginError::UnknownComponent(component.clone()))?;
     let builtin_component = REGISTRY
         .components
-        .get(name)
+        .get(component.path())
         .ok_or_else(|| PluginError::UnknownComponent(component.clone()))?;
 
     Ok(builtin_component.clone())

--- a/stepflow-rs/crates/stepflow-components-mcp/src/plugin.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/src/plugin.rs
@@ -349,7 +349,7 @@ impl Plugin for McpPlugin {
     }
 
     async fn component_info(&self, component: &Component) -> Result<ComponentInfo> {
-        let tool_name = component_path_to_tool_name(component.path_string())
+        let tool_name = component_path_to_tool_name(component.path())
             .ok_or_else(|| error_stack::report!(PluginError::ComponentInfo))?;
 
         let state = self.state.read().await;
@@ -368,7 +368,7 @@ impl Plugin for McpPlugin {
         _context: ExecutionContext,
         input: ValueRef,
     ) -> Result<FlowResult> {
-        let tool_name = component_path_to_tool_name(component.path_string())
+        let tool_name = component_path_to_tool_name(component.path())
             .ok_or_else(|| error_stack::report!(PluginError::Execution))?;
 
         let mut state = self.state.write().await;

--- a/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
@@ -84,7 +84,7 @@ async fn test_mcp_plugin_initialization() {
     // Check that the component paths are correct
     let paths: Vec<String> = components
         .iter()
-        .map(|c| c.component.path_string().to_string())
+        .map(|c| c.component.path().to_string())
         .collect();
     assert!(paths.contains(&"/mock-server/echo".to_string()));
     assert!(paths.contains(&"/mock-server/add".to_string()));

--- a/stepflow-rs/crates/stepflow-core/src/workflow/component.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/component.rs
@@ -12,7 +12,7 @@
 // the License.
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 /// Identifies a specific plugin and atomic functionality to execute.
 ///
@@ -20,17 +20,11 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// - The plugin name
 /// - The component name within that plugin
 /// - Optional sub-path for specific functionality
-///
-/// Components can be specified as:
-/// - Full paths: "/mock/test", "/mcp/my-tool/component"
-/// - Builtin names: "eval", "load_file" (treated as builtin components)
-#[derive(Debug, Eq, PartialEq, Clone, Hash, utoipa::ToSchema)]
-pub struct Component {
-    /// The component path as a string
-    path: String,
-    /// Position of the first slash in the path, if any (for efficient parsing)
-    delimiter: usize,
-}
+#[derive(
+    Debug, Eq, PartialEq, Clone, Hash, utoipa::ToSchema, Serialize, Deserialize, Ord, PartialOrd,
+)]
+#[repr(transparent)]
+pub struct Component(String);
 
 impl JsonSchema for Component {
     fn schema_name() -> std::borrow::Cow<'static, str> {
@@ -42,7 +36,7 @@ impl JsonSchema for Component {
             "type": "string",
             "description": "Identifies a specific plugin and atomic functionality to execute. Use component name for builtins (e.g., 'eval') or path format for plugins (e.g., '/python/udf').",
             "examples": [
-                "eval",
+                "/builtin/eval",
                 "/mcpfs/list_files",
                 "/python/udf",
             ]
@@ -50,119 +44,30 @@ impl JsonSchema for Component {
     }
 }
 
-impl PartialOrd for Component {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Component {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.path.cmp(&other.path)
-    }
-}
-
 impl std::fmt::Display for Component {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.path)
+        write!(f, "{}", self.0)
     }
 }
 
 impl Component {
     /// Creates a new component for a specific plugin.
     pub fn for_plugin(plugin: &str, component_path: &str) -> Self {
-        Self {
-            path: format!("/{plugin}/{component_path}"),
-            delimiter: 1, // Position after the first slash
-        }
+        debug_assert!(
+            component_path.starts_with('/'),
+            "component_path must start with '/'"
+        );
+        Self(format!("/{plugin}{component_path}"))
     }
 
     /// Creates a component from a string, handling both paths and builtin names.
-    pub fn from_string(input: &str) -> Self {
-        if let Some(absolute_path) = input.strip_prefix("/") {
-            // Path-based component
-            match absolute_path.find('/') {
-                Some(pos) => Self {
-                    path: input.to_string(),
-                    delimiter: pos + 2, // Position after the plugin name and second slash
-                },
-                None => {
-                    // Just plugin name like "/plugin", treat as error or default
-                    Self {
-                        path: input.to_string(),
-                        delimiter: input.len(),
-                    }
-                }
-            }
-        } else {
-            // Builtin component (no leading slash)
-            Self {
-                path: input.to_string(),
-                delimiter: 0, // No plugin delimiter for builtins
-            }
-        }
+    pub fn from_string(input: impl Into<String>) -> Self {
+        Self(input.into())
     }
 
     /// Returns the full path string of the component.
-    pub fn path_string(&self) -> &str {
-        &self.path
-    }
-
-    /// Returns true if this is a builtin component.
-    pub fn is_builtin(&self) -> bool {
-        !self.path.starts_with('/')
-    }
-
-    /// Returns the builtin name if this is a builtin component.
-    pub fn builtin_name(&self) -> Option<&str> {
-        if self.is_builtin() {
-            Some(&self.path)
-        } else {
-            None
-        }
-    }
-
-    /// Returns the plugin name of the component.
-    ///
-    /// For example, for "/mcp-files/example", returns "mcp-files".
-    /// For builtin components, returns "builtin".
-    pub fn plugin(&self) -> &str {
-        if self.is_builtin() {
-            "builtin"
-        } else {
-            // Find the plugin name between the first and second slash
-            let without_leading_slash = &self.path[1..];
-            match without_leading_slash.find('/') {
-                Some(pos) => &without_leading_slash[0..pos],
-                None => without_leading_slash, // Only plugin name, no component path
-            }
-        }
-    }
-}
-
-// Custom serialization: output just the path string
-impl Serialize for Component {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // For builtin components, serialize just the builtin name
-        if self.is_builtin() {
-            self.builtin_name().unwrap_or("").serialize(serializer)
-        } else {
-            self.path.serialize(serializer)
-        }
-    }
-}
-
-// Custom deserialization: parse delimiter and handle builtins
-impl<'de> Deserialize<'de> for Component {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let input = String::deserialize(deserializer)?;
-        Ok(Self::from_string(&input))
+    pub fn path(&self) -> &str {
+        &self.0
     }
 }
 
@@ -172,45 +77,12 @@ mod tests {
 
     #[test]
     fn test_component_new() {
-        let component = Component::for_plugin("mock", "test");
-        assert_eq!(component.path_string(), "/mock/test");
-        assert_eq!(component.plugin(), "mock");
-        assert!(!component.is_builtin());
-    }
-
-    #[test]
-    fn test_component_builtin() {
-        let component = Component::from_string("eval");
-        assert_eq!(component.path_string(), "eval");
-        assert_eq!(component.plugin(), "builtin");
-        assert!(component.is_builtin());
-        assert_eq!(component.builtin_name(), Some("eval"));
-    }
-
-    #[test]
-    fn test_component_from_string_path() {
-        let component = Component::from_string("/mcp/tool/component");
-        assert_eq!(component.path_string(), "/mcp/tool/component");
-        assert_eq!(component.plugin(), "mcp");
-        assert!(!component.is_builtin());
-    }
-
-    #[test]
-    fn test_component_from_string_builtin() {
-        let component = Component::from_string("load_file");
-        assert_eq!(component.plugin(), "builtin");
-        assert!(component.is_builtin());
-        assert_eq!(component.builtin_name(), Some("load_file"));
+        let component = Component::for_plugin("mock", "/test");
+        assert_eq!(component.path(), "/mock/test");
     }
 
     #[test]
     fn test_component_serialization() {
-        // Test builtin serialization
-        let component = Component::from_string("eval");
-        let json = serde_json::to_string(&component).unwrap();
-        assert_eq!(json, "\"eval\"");
-
-        // Test path serialization
         let component = Component::from_string("/mock/test");
         let json = serde_json::to_string(&component).unwrap();
         assert_eq!(json, "\"/mock/test\"");
@@ -218,39 +90,14 @@ mod tests {
 
     #[test]
     fn test_component_deserialization() {
-        // Test builtin deserialization
-        let component: Component = serde_json::from_str("\"eval\"").unwrap();
-        assert!(component.is_builtin());
-        assert_eq!(component.builtin_name(), Some("eval"));
-
         // Test path deserialization
         let component: Component = serde_json::from_str("\"/mock/test\"").unwrap();
-        assert!(!component.is_builtin());
-        assert_eq!(component.path_string(), "/mock/test");
-    }
-
-    #[test]
-    fn test_component_roundtrip() {
-        let test_cases = vec!["eval", "load_file", "/mock/test", "/mcp/tool/comp"];
-
-        for case in test_cases {
-            let component = Component::from_string(case);
-            let json = serde_json::to_string(&component).unwrap();
-            let deserialized: Component = serde_json::from_str(&json).unwrap();
-
-            if component.is_builtin() {
-                assert_eq!(component.builtin_name(), deserialized.builtin_name());
-            } else {
-                assert_eq!(component.path_string(), deserialized.path_string());
-            }
-        }
+        assert_eq!(component.path(), "/mock/test");
     }
 
     #[test]
     fn test_new_plugin() {
-        let component = Component::for_plugin("mcp", "tool/component");
-        assert_eq!(component.path_string(), "/mcp/tool/component");
-        assert_eq!(component.plugin(), "mcp");
-        assert!(!component.is_builtin());
+        let component = Component::for_plugin("mcp", "/tool/component");
+        assert_eq!(component.path(), "/mcp/tool/component");
     }
 }

--- a/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
@@ -391,9 +391,9 @@ mod tests {
 
         // Verify step details
         assert_eq!(flow.steps[0].id, "s1");
-        assert_eq!(flow.steps[0].component.path_string(), "/langflow/echo");
+        assert_eq!(flow.steps[0].component.path(), "/langflow/echo");
         assert_eq!(flow.steps[1].id, "s2");
-        assert_eq!(flow.steps[1].component.path_string(), "/mcp/foo/bar");
+        assert_eq!(flow.steps[1].component.path(), "/mcp/foo/bar");
 
         // Test round-trip serialization to ensure expressions are preserved
         let serialized = serde_json::to_string(&flow).unwrap();

--- a/stepflow-rs/crates/stepflow-execution/src/executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/executor.rs
@@ -105,20 +105,25 @@ impl StepFlowExecutor {
         self.state_store.clone()
     }
 
-    pub async fn get_plugin(
+    pub async fn get_plugin_and_component(
         &self,
         component: &Component,
         input: ValueRef,
-    ) -> Result<&Arc<DynPlugin<'static>>> {
-        // Use the integrated plugin router to get the plugin directly
+    ) -> Result<(&Arc<DynPlugin<'static>>, String)> {
+        // Use the integrated plugin router to get the plugin and resolved component name
         self.plugin_router
-            .get_plugin(component.path_string(), input)
+            .get_plugin_and_component(component.path(), input)
             .change_context(ExecutionError::RouterError)
     }
 
     /// List all registered plugins
     pub async fn list_plugins(&self) -> Vec<&Arc<DynPlugin<'static>>> {
         self.plugin_router.plugins().collect()
+    }
+
+    /// Get the plugin router for accessing routing functionality
+    pub fn plugin_router(&self) -> &PluginRouter {
+        &self.plugin_router
     }
 
     /// Get or create a debug session for step-by-step execution control

--- a/stepflow-rs/crates/stepflow-main/src/args/workflow.rs
+++ b/stepflow-rs/crates/stepflow-main/src/args/workflow.rs
@@ -34,7 +34,8 @@ async fn create_executor_impl(config: StepflowConfig) -> Result<Arc<StepFlowExec
         .expect("working_directory");
 
     // Build the plugin router
-    let mut plugin_router_builder = PluginRouter::builder().with_routing_rules(config.routing);
+    tracing::info!("Routing Config: {:?}", config.routing);
+    let mut plugin_router_builder = PluginRouter::builder().with_routing_config(config.routing);
 
     // Register plugins from IndexMap
     for (plugin_name, plugin_config) in config.plugins {

--- a/stepflow-rs/crates/stepflow-main/src/cli.rs
+++ b/stepflow-rs/crates/stepflow-main/src/cli.rs
@@ -130,6 +130,12 @@ pub enum Command {
         /// Defaults to false for pretty format, true for json/yaml formats.
         #[arg(long = "schemas")]
         schemas: Option<bool>,
+
+        /// Hide components that are not reachable through any routing rule.
+        ///
+        /// Use --no-hide-unreachable to show all components regardless of routing.
+        #[arg(long = "hide-unreachable", default_value = "true", action = clap::ArgAction::Set)]
+        hide_unreachable: bool,
     },
     /// Start an interactive REPL for workflow development and debugging.
     Repl {
@@ -202,9 +208,15 @@ impl Cli {
                 config_args,
                 format,
                 schemas,
+                hide_unreachable,
             } => {
-                crate::list_components::list_components(config_args.config_path, format, schemas)
-                    .await?;
+                crate::list_components::list_components(
+                    config_args.config_path,
+                    format,
+                    schemas,
+                    hide_unreachable,
+                )
+                .await?;
             }
             Command::Repl { config_args } => {
                 run_repl(config_args.config_path).await?;

--- a/stepflow-rs/crates/stepflow-main/src/list_components.rs
+++ b/stepflow-rs/crates/stepflow-main/src/list_components.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use stepflow_core::component::ComponentInfo;
 use stepflow_plugin::Plugin as _;
+use stepflow_plugin::routing::RouteMatch;
 
 /// Output format for command line display
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -29,8 +30,18 @@ pub enum OutputFormat {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct ComponentWithRoutes {
+    #[serde(flatten)]
+    pub component_info: ComponentInfo,
+    /// The plugin that provides this component
+    pub plugin: String,
+    /// Available routes for accessing this component
+    pub routes: Vec<RouteMatch>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ComponentList {
-    pub components: Vec<ComponentInfo>,
+    pub components: Vec<ComponentWithRoutes>,
 }
 
 /// List all available components from a stepflow config.
@@ -38,6 +49,7 @@ pub async fn list_components(
     config_path: Option<PathBuf>,
     format: OutputFormat,
     schemas: Option<bool>,
+    hide_unreachable: bool,
 ) -> Result<()> {
     // Determine whether to include schemas based on format and explicit flag
     let include_schemas = schemas.unwrap_or(match format {
@@ -51,29 +63,52 @@ pub async fn list_components(
     // Create executor to instantiate plugins
     let executor = WorkflowLoader::create_executor_from_config(config).await?;
 
-    // Get all registered plugins and query their components
+    // Get all registered plugins and query their components with routing information
     let mut all_components = Vec::new();
 
-    // Get the list of plugins from the executor
-    for plugin in executor.list_plugins().await {
+    // Get the plugin router to access reverse routing functionality
+    let plugin_router = executor.plugin_router();
+
+    // Iterate over plugins with their names
+    for (plugin_name, plugin) in plugin_router.plugins_with_names() {
         // List components available from this plugin
         let components = plugin
             .list_components()
             .await
             .change_context(MainError::PluginCommunication)?;
 
-        // Components are already ComponentInfo structs, just filter schemas if needed
+        // For each component, find its routes using reverse routing
         for mut info in components {
             if !include_schemas {
                 info.input_schema = None;
                 info.output_schema = None;
             }
-            all_components.push(info);
+
+            let component_name = info.component.path();
+
+            // Find routes for this plugin/component combination
+            let routes = plugin_router.find_routes_for(plugin_name, component_name);
+
+            all_components.push(ComponentWithRoutes {
+                component_info: info,
+                plugin: plugin_name.to_string(),
+                routes,
+            });
         }
     }
 
+    // Filter out unreachable components if requested
+    if hide_unreachable {
+        all_components.retain(|component| !component.routes.is_empty());
+    }
+
     // Sort components by their URL for consistent output
-    all_components.sort_by(|a, b| a.component.to_string().cmp(&b.component.to_string()));
+    all_components.sort_by(|a, b| {
+        a.component_info
+            .component
+            .to_string()
+            .cmp(&b.component_info.component.to_string())
+    });
 
     let component_list = ComponentList {
         components: all_components,
@@ -97,7 +132,7 @@ pub async fn list_components(
     Ok(())
 }
 
-fn print_pretty(components: &[ComponentInfo]) {
+fn print_pretty(components: &[ComponentWithRoutes]) {
     if components.is_empty() {
         println!("No components found.");
         return;
@@ -108,15 +143,34 @@ fn print_pretty(components: &[ComponentInfo]) {
 
     for component in components {
         println!();
-        println!("Component: {}", component.component);
+        println!(
+            "Component: {} (plugin: {})",
+            component.component_info.component, component.plugin
+        );
 
         // Print description if present
-        if let Some(ref description) = component.description {
+        if let Some(ref description) = component.component_info.description {
             println!("  Description: {description}");
         }
 
+        // Print available routes
+        if !component.routes.is_empty() {
+            println!("  Available Routes:");
+            for route in &component.routes {
+                println!("    {}", route.resolved_path);
+                if !route.conditions.is_empty() {
+                    println!("      Conditions:");
+                    for condition in &route.conditions {
+                        println!("        {}: {:?}", condition.path, condition.value);
+                    }
+                }
+            }
+        } else {
+            println!("  Available Routes: None");
+        }
+
         // Print input schema if present
-        if let Some(ref input_schema) = component.input_schema {
+        if let Some(ref input_schema) = component.component_info.input_schema {
             println!("  Input Schema:");
             let input_schema_str = serde_json::to_string_pretty(input_schema)
                 .unwrap_or_else(|_| "Error serializing schema".to_string());
@@ -126,7 +180,7 @@ fn print_pretty(components: &[ComponentInfo]) {
         }
 
         // Print output schema if present
-        if let Some(ref output_schema) = component.output_schema {
+        if let Some(ref output_schema) = component.component_info.output_schema {
             println!("  Output Schema:");
             let output_schema_str = serde_json::to_string_pretty(output_schema)
                 .unwrap_or_else(|_| "Error serializing schema".to_string());

--- a/stepflow-rs/crates/stepflow-main/src/stepflow_config.rs
+++ b/stepflow-rs/crates/stepflow-main/src/stepflow_config.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use stepflow_builtins::BuiltinPluginConfig;
 use stepflow_components_mcp::McpPluginConfig;
 use stepflow_mock::MockPlugin;
-use stepflow_plugin::routing::RoutingRule;
+use stepflow_plugin::routing::RoutingConfig;
 use stepflow_plugin::{DynPlugin, PluginConfig};
 use stepflow_protocol::StepflowPluginConfig;
 use stepflow_state::{InMemoryStateStore, StateStore};
@@ -34,9 +34,9 @@ pub struct StepflowConfig {
     /// If not set, this will be the directory containing the config.
     pub working_directory: Option<PathBuf>,
     pub plugins: IndexMap<String, SupportedPluginConfig>,
-    /// Routing rules for mapping components to plugins.
-    #[serde(default)]
-    pub routing: Vec<RoutingRule>,
+    /// Routing configuration for mapping components to plugins.
+    #[serde(flatten)]
+    pub routing: RoutingConfig,
     /// State store configuration. If not specified, uses in-memory storage.
     #[serde(default)]
     pub state_store: StateStoreConfig,
@@ -55,7 +55,7 @@ impl Default for StepflowConfig {
         Self {
             working_directory: None,
             plugins,
-            routing: Vec::new(),
+            routing: RoutingConfig::default(),
             state_store: StateStoreConfig::default(),
         }
     }

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_default.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_default.snap
@@ -15,29 +15,45 @@ exit_code: 0
 Available Components:
 ====================
 
-Component: /builtin/create_messages
+Component: /create_messages (plugin: builtin)
   Description: Create a chat message list from system instructions and user prompt
+  Available Routes:
+    /builtin/create_messages
 
-Component: /builtin/eval
+Component: /eval (plugin: builtin)
   Description: Execute a nested workflow with given input and return the result
+  Available Routes:
+    /builtin/eval
 
-Component: /builtin/get_blob
+Component: /get_blob (plugin: builtin)
   Description: Retrieve JSON data from a blob using its ID
+  Available Routes:
+    /builtin/get_blob
 
-Component: /builtin/iterate
+Component: /iterate (plugin: builtin)
   Description: Iteratively apply a workflow until it returns a result instead of next
+  Available Routes:
+    /builtin/iterate
 
-Component: /builtin/load_file
+Component: /load_file (plugin: builtin)
   Description: Load and parse a file (JSON, YAML, or text) from the filesystem
+  Available Routes:
+    /builtin/load_file
 
-Component: /builtin/map
+Component: /map (plugin: builtin)
   Description: Apply a workflow to each item in a list and collect the results
+  Available Routes:
+    /builtin/map
 
-Component: /builtin/openai
+Component: /openai (plugin: builtin)
   Description: Send messages to OpenAI's chat completion API and get a response
+  Available Routes:
+    /builtin/openai
 
-Component: /builtin/put_blob
+Component: /put_blob (plugin: builtin)
   Description: Store JSON data as a blob and return its content-addressable ID
+  Available Routes:
+    /builtin/put_blob
 
 Total components: 8
 

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_json.snap
@@ -16,7 +16,7 @@ exit_code: 0
 {
   "components": [
     {
-      "component": "/builtin/create_messages",
+      "component": "/create_messages",
       "description": "Create a chat message list from system instructions and user prompt",
       "input_schema": {
         "type": "object",
@@ -50,10 +50,19 @@ exit_code: 0
         "required": [
           "messages"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/create_messages",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/eval",
+      "component": "/eval",
       "description": "Execute a nested workflow with given input and return the result",
       "input_schema": {
         "description": "Input for the eval component",
@@ -101,10 +110,19 @@ exit_code: 0
           "result",
           "run_id"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/eval",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/get_blob",
+      "component": "/get_blob",
       "description": "Retrieve JSON data from a blob using its ID",
       "input_schema": {
         "description": "Input for the get_blob component",
@@ -130,10 +148,19 @@ exit_code: 0
         "required": [
           "data"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/get_blob",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/iterate",
+      "component": "/iterate",
       "description": "Iteratively apply a workflow until it returns a result instead of next",
       "input_schema": {
         "description": "Input for the iterate component",
@@ -184,10 +211,19 @@ exit_code: 0
           "iterations",
           "terminated"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/iterate",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/load_file",
+      "component": "/load_file",
       "description": "Load and parse a file (JSON, YAML, or text) from the filesystem",
       "input_schema": {
         "type": "object",
@@ -227,10 +263,19 @@ exit_code: 0
           "data",
           "metadata"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/load_file",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/map",
+      "component": "/map",
       "description": "Apply a workflow to each item in a list and collect the results",
       "input_schema": {
         "description": "Input for the map component",
@@ -287,10 +332,19 @@ exit_code: 0
           "failed",
           "skipped"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/map",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/openai",
+      "component": "/openai",
       "description": "Send messages to OpenAI's chat completion API and get a response",
       "input_schema": {
         "description": "Input for the OpenAI component",
@@ -345,10 +399,19 @@ exit_code: 0
         "required": [
           "response"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/openai",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/put_blob",
+      "component": "/put_blob",
       "description": "Store JSON data as a blob and return its content-addressable ID",
       "input_schema": {
         "description": "Input for the put_blob component",
@@ -374,7 +437,16 @@ exit_code: 0
         "required": [
           "blob_id"
         ]
-      }
+      },
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/put_blob",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     }
   ]
 }

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_format_yaml.snap
@@ -14,7 +14,7 @@ success: true
 exit_code: 0
 ----- stdout -----
 components:
-- component: /builtin/create_messages
+- component: /create_messages
   description: Create a chat message list from system instructions and user prompt
   input_schema:
     type: object
@@ -38,7 +38,13 @@ components:
           $ref: '#/$defs/ChatMessage'
     required:
     - messages
-- component: /builtin/eval
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/create_messages
+    conditions: []
+    is_conditional: false
+- component: /eval
   description: Execute a nested workflow with given input and return the result
   input_schema:
     description: Input for the eval component
@@ -74,7 +80,13 @@ components:
     required:
     - result
     - run_id
-- component: /builtin/get_blob
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/eval
+    conditions: []
+    is_conditional: false
+- component: /get_blob
   description: Retrieve JSON data from a blob using its ID
   input_schema:
     description: Input for the get_blob component
@@ -93,7 +105,13 @@ components:
         description: The JSON data stored in the blob
     required:
     - data
-- component: /builtin/iterate
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/get_blob
+    conditions: []
+    is_conditional: false
+- component: /iterate
   description: Iteratively apply a workflow until it returns a result instead of next
   input_schema:
     description: Input for the iterate component
@@ -133,7 +151,13 @@ components:
     - result
     - iterations
     - terminated
-- component: /builtin/load_file
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/iterate
+    conditions: []
+    is_conditional: false
+- component: /load_file
   description: Load and parse a file (JSON, YAML, or text) from the filesystem
   input_schema:
     type: object
@@ -159,7 +183,13 @@ components:
     required:
     - data
     - metadata
-- component: /builtin/map
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/load_file
+    conditions: []
+    is_conditional: false
+- component: /map
   description: Apply a workflow to each item in a list and collect the results
   input_schema:
     description: Input for the map component
@@ -203,7 +233,13 @@ components:
     - successful
     - failed
     - skipped
-- component: /builtin/openai
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/map
+    conditions: []
+    is_conditional: false
+- component: /openai
   description: Send messages to OpenAI's chat completion API and get a response
   input_schema:
     description: Input for the OpenAI component
@@ -244,7 +280,13 @@ components:
         type: string
     required:
     - response
-- component: /builtin/put_blob
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/openai
+    conditions: []
+    is_conditional: false
+- component: /put_blob
   description: Store JSON data as a blob and return its content-addressable ID
   input_schema:
     description: Input for the put_blob component
@@ -263,6 +305,12 @@ components:
         type: string
     required:
     - blob_id
+  plugin: builtin
+  routes:
+  - path_pattern: /builtin/{*component}
+    resolved_path: /builtin/put_blob
+    conditions: []
+    is_conditional: false
 
 
 ----- stderr -----

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_help.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_help.snap
@@ -50,6 +50,14 @@ Options:
           
           [possible values: true, false]
 
+      --hide-unreachable <HIDE_UNREACHABLE>
+          Hide components that are not reachable through any routing rule.
+          
+          Use --no-hide-unreachable to show all components regardless of routing.
+          
+          [default: true]
+          [possible values: true, false]
+
       --omit-stack-trace
           Omit stack traces (line numbers of errors)
 

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_hide_unreachable.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_hide_unreachable.snap
@@ -1,0 +1,30 @@
+---
+source: crates/stepflow-main/tests/commands/test_list_components.rs
+info:
+  program: stepflow
+  args:
+    - "--log-file=/dev/null"
+    - "--omit-stack-trace"
+    - "--log-level=error"
+    - list-components
+    - "--config=/var/folders/c4/dcr0mh3d183d5kh9gf89wsc00000gn/T/.tmpu5zzRH/filtered-config.yml"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Available Components:
+====================
+
+Component: /create_messages (plugin: test-builtins)
+  Description: Create a chat message list from system instructions and user prompt
+  Available Routes:
+    /reachable/create_messages
+
+Component: /openai (plugin: test-builtins)
+  Description: Send messages to OpenAI's chat completion API and get a response
+  Available Routes:
+    /reachable/openai
+
+Total components: 2
+
+----- stderr -----

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_json_no_schemas.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_json_no_schemas.snap
@@ -17,36 +17,108 @@ exit_code: 0
 {
   "components": [
     {
-      "component": "/builtin/create_messages",
-      "description": "Create a chat message list from system instructions and user prompt"
+      "component": "/create_messages",
+      "description": "Create a chat message list from system instructions and user prompt",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/create_messages",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/eval",
-      "description": "Execute a nested workflow with given input and return the result"
+      "component": "/eval",
+      "description": "Execute a nested workflow with given input and return the result",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/eval",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/get_blob",
-      "description": "Retrieve JSON data from a blob using its ID"
+      "component": "/get_blob",
+      "description": "Retrieve JSON data from a blob using its ID",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/get_blob",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/iterate",
-      "description": "Iteratively apply a workflow until it returns a result instead of next"
+      "component": "/iterate",
+      "description": "Iteratively apply a workflow until it returns a result instead of next",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/iterate",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/load_file",
-      "description": "Load and parse a file (JSON, YAML, or text) from the filesystem"
+      "component": "/load_file",
+      "description": "Load and parse a file (JSON, YAML, or text) from the filesystem",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/load_file",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/map",
-      "description": "Apply a workflow to each item in a list and collect the results"
+      "component": "/map",
+      "description": "Apply a workflow to each item in a list and collect the results",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/map",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/openai",
-      "description": "Send messages to OpenAI's chat completion API and get a response"
+      "component": "/openai",
+      "description": "Send messages to OpenAI's chat completion API and get a response",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/openai",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     },
     {
-      "component": "/builtin/put_blob",
-      "description": "Store JSON data as a blob and return its content-addressable ID"
+      "component": "/put_blob",
+      "description": "Store JSON data as a blob and return its content-addressable ID",
+      "plugin": "builtin",
+      "routes": [
+        {
+          "path_pattern": "/builtin/{*component}",
+          "resolved_path": "/builtin/put_blob",
+          "conditions": [],
+          "is_conditional": false
+        }
+      ]
     }
   ]
 }

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_show_unreachable.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_show_unreachable.snap
@@ -7,7 +7,8 @@ info:
     - "--omit-stack-trace"
     - "--log-level=error"
     - list-components
-    - "--config=/var/folders/c4/dcr0mh3d183d5kh9gf89wsc00000gn/T/.tmps4TvA1/custom-config.yml"
+    - "--config=/var/folders/c4/dcr0mh3d183d5kh9gf89wsc00000gn/T/.tmpmN9KLx/filtered-config.yml"
+    - "--hide-unreachable=false"
 ---
 success: true
 exit_code: 0
@@ -18,42 +19,36 @@ Available Components:
 Component: /create_messages (plugin: test-builtins)
   Description: Create a chat message list from system instructions and user prompt
   Available Routes:
-    /test-builtins/create_messages
+    /reachable/create_messages
 
 Component: /eval (plugin: test-builtins)
   Description: Execute a nested workflow with given input and return the result
-  Available Routes:
-    /test-builtins/eval
+  Available Routes: None
 
 Component: /get_blob (plugin: test-builtins)
   Description: Retrieve JSON data from a blob using its ID
-  Available Routes:
-    /test-builtins/get_blob
+  Available Routes: None
 
 Component: /iterate (plugin: test-builtins)
   Description: Iteratively apply a workflow until it returns a result instead of next
-  Available Routes:
-    /test-builtins/iterate
+  Available Routes: None
 
 Component: /load_file (plugin: test-builtins)
   Description: Load and parse a file (JSON, YAML, or text) from the filesystem
-  Available Routes:
-    /test-builtins/load_file
+  Available Routes: None
 
 Component: /map (plugin: test-builtins)
   Description: Apply a workflow to each item in a list and collect the results
-  Available Routes:
-    /test-builtins/map
+  Available Routes: None
 
 Component: /openai (plugin: test-builtins)
   Description: Send messages to OpenAI's chat completion API and get a response
   Available Routes:
-    /test-builtins/openai
+    /reachable/openai
 
 Component: /put_blob (plugin: test-builtins)
   Description: Store JSON data as a blob and return its content-addressable ID
-  Available Routes:
-    /test-builtins/put_blob
+  Available Routes: None
 
 Total components: 8
 

--- a/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
+++ b/stepflow-rs/crates/stepflow-main/tests/commands/snapshots/test_cli__commands__test_list_components__list_components_with_schemas.snap
@@ -16,8 +16,10 @@ exit_code: 0
 Available Components:
 ====================
 
-Component: /builtin/create_messages
+Component: /create_messages (plugin: builtin)
   Description: Create a chat message list from system instructions and user prompt
+  Available Routes:
+    /builtin/create_messages
   Input Schema:
     {
       "type": "object",
@@ -54,8 +56,10 @@ Component: /builtin/create_messages
       ]
     }
 
-Component: /builtin/eval
+Component: /eval (plugin: builtin)
   Description: Execute a nested workflow with given input and return the result
+  Available Routes:
+    /builtin/eval
   Input Schema:
     {
       "description": "Input for the eval component",
@@ -106,8 +110,10 @@ Component: /builtin/eval
       ]
     }
 
-Component: /builtin/get_blob
+Component: /get_blob (plugin: builtin)
   Description: Retrieve JSON data from a blob using its ID
+  Available Routes:
+    /builtin/get_blob
   Input Schema:
     {
       "description": "Input for the get_blob component",
@@ -136,8 +142,10 @@ Component: /builtin/get_blob
       ]
     }
 
-Component: /builtin/iterate
+Component: /iterate (plugin: builtin)
   Description: Iteratively apply a workflow until it returns a result instead of next
+  Available Routes:
+    /builtin/iterate
   Input Schema:
     {
       "description": "Input for the iterate component",
@@ -191,8 +199,10 @@ Component: /builtin/iterate
       ]
     }
 
-Component: /builtin/load_file
+Component: /load_file (plugin: builtin)
   Description: Load and parse a file (JSON, YAML, or text) from the filesystem
+  Available Routes:
+    /builtin/load_file
   Input Schema:
     {
       "type": "object",
@@ -235,8 +245,10 @@ Component: /builtin/load_file
       ]
     }
 
-Component: /builtin/map
+Component: /map (plugin: builtin)
   Description: Apply a workflow to each item in a list and collect the results
+  Available Routes:
+    /builtin/map
   Input Schema:
     {
       "description": "Input for the map component",
@@ -296,8 +308,10 @@ Component: /builtin/map
       ]
     }
 
-Component: /builtin/openai
+Component: /openai (plugin: builtin)
   Description: Send messages to OpenAI's chat completion API and get a response
+  Available Routes:
+    /builtin/openai
   Input Schema:
     {
       "description": "Input for the OpenAI component",
@@ -355,8 +369,10 @@ Component: /builtin/openai
       ]
     }
 
-Component: /builtin/put_blob
+Component: /put_blob (plugin: builtin)
   Description: Store JSON data as a blob and return its content-addressable ID
+  Available Routes:
+    /builtin/put_blob
   Input Schema:
     {
       "description": "Input for the put_blob component",

--- a/stepflow-rs/crates/stepflow-plugin/Cargo.toml
+++ b/stepflow-rs/crates/stepflow-plugin/Cargo.toml
@@ -19,14 +19,16 @@ doctest = false
 dynosaur.workspace = true
 error-stack.workspace = true
 futures.workspace = true
-globset.workspace = true
+indexmap.workspace = true
+matchit.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde_with.workspace = true
 stepflow-core.workspace = true
 stepflow-state.workspace = true
 thiserror.workspace = true
 trait-variant.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+serde_yaml_ng.workspace = true

--- a/stepflow-rs/crates/stepflow-plugin/src/routing.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing.rs
@@ -17,4 +17,4 @@ mod rules;
 
 pub use plugin_router::{PluginRouter, PluginRouterBuilder};
 pub use router::{ComponentRouter, Router, RouterError};
-pub use rules::{InputCondition, MatchRule, RoutingRule};
+pub use rules::{InputCondition, RouteMatch, RouteRule, RoutingConfig};

--- a/stepflow-rs/crates/stepflow-plugin/src/routing/plugin_router.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing/plugin_router.rs
@@ -15,10 +15,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::Router;
-use crate::routing::RoutingRule;
+use crate::routing::{RouteMatch, RouteRule, RoutingConfig};
 use crate::{DynPlugin, PluginError, Result};
 use error_stack::ResultExt as _;
-use stepflow_core::workflow::ValueRef;
+use indexmap::IndexMap;
+use stepflow_core::values::ValueRef;
 
 /// Integrated plugin router that combines routing logic with plugin management.
 ///
@@ -27,12 +28,9 @@ use stepflow_core::workflow::ValueRef;
 pub struct PluginRouter {
     /// The underlying router for component path resolution
     router: Router,
-    /// Plugin instances indexed by routing rule index
-    /// Each routing rule index maps directly to a plugin instance
-    plugins: Vec<Arc<DynPlugin<'static>>>,
-    /// Unique plugin instances (no duplicates)
-    /// Used for initialization to ensure each plugin is only initialized once
-    unique_plugins: Vec<Arc<DynPlugin<'static>>>,
+    /// Ordered mapping from plugin names to their instances
+    /// IndexMap maintains insertion order and provides both name-based and index-based access
+    plugins: IndexMap<String, Arc<DynPlugin<'static>>>,
 }
 
 impl PluginRouter {
@@ -41,67 +39,85 @@ impl PluginRouter {
         PluginRouterBuilder::new()
     }
 
-    /// Get a plugin for the given component path and input data
-    pub fn get_plugin(
+    /// Get a plugin and resolved component name for the given component path and input data
+    pub fn get_plugin_and_component(
         &self,
         component_path: &str,
         input: ValueRef,
-    ) -> Result<&Arc<DynPlugin<'static>>> {
-        // NOTE: If the component router step is expensive, we could instead
-        // have this return the `ComponentRouter` and allow the caller to store
-        // that. This would allow determining if there is a static route, as
-        // well as re-using the path based routing.
-
+    ) -> Result<(&Arc<DynPlugin<'static>>, String)> {
         // Route the component path to get a component router
         let component_router = self
             .router
-            .route(component_path.to_string())
+            .route(component_path)
             .change_context(PluginError::InvalidInput)?;
 
-        // Resolve the input to get the rule index
-        let rule_index = component_router
-            .route_input(input)
+        // Resolve the input to get the route rule and component name
+        let (route_rule, resolved_component) = component_router
+            .get_route_and_component(input)
             .change_context(PluginError::InvalidInput)?;
 
-        // Get the plugin directly by rule index
-        self.plugins
-            .get(rule_index)
-            .ok_or(PluginError::InvalidRuleIndex(rule_index))
-            .map_err(|e| e.into())
+        tracing::info!(
+            "Component '{component_path}' routed to '{resolved_component}' on plugin '{}'",
+            route_rule.rule.plugin
+        );
+
+        // Get the plugin by index.
+        let plugin = self
+            .plugins
+            .get_index(route_rule.plugin_index)
+            .expect("Plugin index should be valid")
+            .1;
+
+        Ok((plugin, resolved_component))
     }
 
     /// Get all registered plugins
     /// This returns each plugin exactly once, even if it's used by multiple routing rules
     pub fn plugins(&self) -> impl Iterator<Item = &Arc<DynPlugin<'static>>> {
-        self.unique_plugins.iter()
+        self.plugins.values()
+    }
+
+    /// Get all registered plugins with their names
+    /// This returns each plugin exactly once with its corresponding name
+    pub fn plugins_with_names(&self) -> impl Iterator<Item = (&str, &Arc<DynPlugin<'static>>)> {
+        self.plugins
+            .iter()
+            .map(|(name, plugin)| (name.as_str(), plugin))
+    }
+
+    /// Find all routes that could match a given plugin and component
+    pub fn find_routes_for(&self, plugin: &str, component: &str) -> Vec<RouteMatch> {
+        self.router.find_routes_for(plugin, component)
     }
 }
 
 /// Builder for constructing a PluginRouter
 pub struct PluginRouterBuilder {
-    /// Routing rules for component path resolution
-    routing_rules: Vec<RoutingRule>,
-    /// Map from plugin name to plugin instance
-    plugins: HashMap<String, Arc<DynPlugin<'static>>>,
+    /// Routing configuration for component path resolution
+    routing_config: RoutingConfig,
+    /// Ordered map from plugin name to plugin instance
+    plugins: IndexMap<String, Arc<DynPlugin<'static>>>,
 }
 
 impl PluginRouterBuilder {
     fn new() -> Self {
         Self {
-            routing_rules: Vec::new(),
-            plugins: HashMap::new(),
+            routing_config: RoutingConfig {
+                routes: HashMap::new(),
+            },
+            plugins: IndexMap::new(),
         }
     }
 
-    /// Add a routing rule to the plugin router being built
-    pub fn with_routing_rule(mut self, rule: RoutingRule) -> Self {
-        self.routing_rules.push(rule);
+    /// Add a routing path with rules to the plugin router being built
+    pub fn with_routing_path(mut self, path: String, rules: Vec<RouteRule>) -> Self {
+        self.routing_config.routes.insert(path, rules);
         self
     }
 
-    /// Add multiple routing rules to the plugin router being built
-    pub fn with_routing_rules(mut self, rules: impl IntoIterator<Item = RoutingRule>) -> Self {
-        self.routing_rules.extend(rules);
+    /// Set the complete routing configuration
+    pub fn with_routing_config(mut self, config: RoutingConfig) -> Self {
+        self.routing_config = config;
         self
     }
 
@@ -113,27 +129,31 @@ impl PluginRouterBuilder {
 
     /// Build the PluginRouter
     pub fn build(self) -> Result<PluginRouter> {
-        // Expand the plugins HashMap into a Vec where each index corresponds to a routing rule
-        let mut plugins = Vec::new();
-        for rule in self.routing_rules.iter() {
-            let plugin_name = rule.target.as_ref();
-            if let Some(plugin) = self.plugins.get(plugin_name) {
-                plugins.push(plugin.clone());
-            } else {
-                return Err(PluginError::PluginNotFound(plugin_name.to_string()).into());
+        // Validate that all plugins referenced in rules exist
+        for (_path, rules) in self.routing_config.routes.iter() {
+            for rule in rules {
+                let plugin_name = rule.plugin.as_ref();
+                if !self.plugins.contains_key(plugin_name) {
+                    return Err(PluginError::PluginNotFound(plugin_name.to_string()).into());
+                }
             }
         }
 
-        // Create a vector of unique plugins (no duplicates)
-        let unique_plugins: Vec<Arc<DynPlugin<'static>>> = self.plugins.into_values().collect();
+        // Create plugin indices map for the router
+        let plugin_indices: HashMap<String, usize> = self
+            .plugins
+            .keys()
+            .enumerate()
+            .map(|(index, name)| (name.clone(), index))
+            .collect();
 
         // Create the underlying router
-        let router = Router::new(self.routing_rules).change_context(PluginError::CreatePlugin)?;
+        let router = Router::new(self.routing_config, &plugin_indices)
+            .change_context(PluginError::CreatePlugin)?;
 
         Ok(PluginRouter {
             router,
-            plugins,
-            unique_plugins,
+            plugins: self.plugins,
         })
     }
 }
@@ -141,7 +161,7 @@ impl PluginRouterBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::routing::rules::{MatchRule, RoutingRule};
+    use crate::routing::rules::{RouteRule, RoutingConfig};
     use serde_json::json;
 
     struct TestPlugin;
@@ -185,71 +205,98 @@ mod tests {
     fn test_plugin_router_basic() {
         let test_plugin = DynPlugin::boxed(TestPlugin);
 
-        let rules = vec![RoutingRule {
-            match_rule: vec![MatchRule {
-                component: "/test/*".to_string(),
-                input: vec![],
+        let mut routes = std::collections::HashMap::new();
+        routes.insert(
+            "/test/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "test".into(),
+                component: None,
             }],
-            target: "test".into(),
-        }];
+        );
+
+        let config = RoutingConfig { routes };
 
         let router = PluginRouter::builder()
-            .with_routing_rules(rules)
+            .with_routing_config(config)
             .register_plugin("test".to_string(), test_plugin)
             .build()
             .unwrap();
 
         let input = ValueRef::new(json!({}));
-        let _plugin = router.get_plugin("/test/example", input).unwrap();
-        // Just verify we can get the plugin back without panicking
+        let (_plugin, path) = router
+            .get_plugin_and_component("/test/example", input)
+            .unwrap();
+        assert_eq!(path, "/example");
     }
 
     #[test]
     fn test_plugin_router_multiple_rules_same_plugin() {
         let test_plugin = DynPlugin::boxed(TestPlugin);
 
-        let rules = vec![
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/test/*".to_string(),
-                    input: vec![],
-                }],
-                target: "test".into(),
-            },
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/other/*".to_string(),
-                    input: vec![],
-                }],
-                target: "test".into(),
-            },
-        ];
+        let mut routes = std::collections::HashMap::new();
+        routes.insert(
+            "/test/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "test".into(),
+                component: None,
+            }],
+        );
+        routes.insert(
+            "/other/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "test".into(),
+                component: None,
+            }],
+        );
+
+        let config = RoutingConfig { routes };
 
         let router = PluginRouter::builder()
-            .with_routing_rules(rules)
+            .with_routing_config(config)
             .register_plugin("test".to_string(), test_plugin)
             .build()
             .unwrap();
 
         let input = ValueRef::new(json!({}));
-        let plugin1 = router.get_plugin("/test/example", input.clone()).unwrap();
-        let plugin2 = router.get_plugin("/other/example", input).unwrap();
+        let (plugin1, path1) = router
+            .get_plugin_and_component("/test/example", input.clone())
+            .unwrap();
+        let (plugin2, path2) = router
+            .get_plugin_and_component("/other/example", input)
+            .unwrap();
 
         // Both should be the same Arc instance
         assert!(Arc::ptr_eq(plugin1, plugin2));
+        assert_eq!(path1, "/example");
+        assert_eq!(path2, "/example");
     }
 
     #[test]
     fn test_plugin_router_missing_plugin() {
-        let rules = vec![RoutingRule {
-            match_rule: vec![MatchRule {
-                component: "/missing/*".to_string(),
-                input: vec![],
+        let mut routes = std::collections::HashMap::new();
+        routes.insert(
+            "/missing/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "nonexistent".into(),
+                component: None,
             }],
-            target: "nonexistent".into(),
-        }];
+        );
 
-        let result = PluginRouter::builder().with_routing_rules(rules).build();
+        let config = RoutingConfig { routes };
+
+        let result = PluginRouter::builder().with_routing_config(config).build();
 
         assert!(result.is_err());
     }

--- a/stepflow-rs/crates/stepflow-plugin/src/routing/router.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing/router.rs
@@ -11,141 +11,309 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
-use crate::routing::{MatchRule, RoutingRule};
+use std::collections::HashMap;
 
-use error_stack::ResultExt as _;
-use globset::{Glob, GlobSet, GlobSetBuilder};
+use crate::routing::{RouteMatch, RouteRule, RoutingConfig};
+
+use matchit::{Params, Router as MatchitRouter};
 use stepflow_core::values::ValueRef;
 use stepflow_core::workflow::JsonPath;
 
-/// Router that matches component strings to target plugins using glob patterns
+/// Router that matches component strings to target plugins using trie-based routing
 #[derive(Debug)]
 pub struct Router {
-    /// Compiled glob patterns for efficient matching
-    glob_set: GlobSet,
-    /// Match rule and target index for the corresponding pattern
-    rules: Vec<(MatchRule, usize)>,
+    /// Matchit router for efficient trie-based routing
+    router: MatchitRouter<Vec<RouteInfo>>,
+    /// Original routing configuration for reverse routing
+    routing_config: RoutingConfig,
+}
+
+/// Information about a matched route
+#[derive(Debug, Clone)]
+pub struct RouteInfo {
+    /// The routing rule for this route
+    pub rule: RouteRule,
+    /// The pattern for this route info.
+    path_pattern: String,
+    /// Plugin index for this route
+    pub plugin_index: usize,
 }
 
 /// A step router that determines how to route a specific component
 #[derive(Debug, Clone)]
 pub enum ComponentRouter<'a> {
     /// Route directly to a specific plugin without input filtering
-    Direct(usize),
+    Direct {
+        route_info: &'a RouteInfo,
+        params: Params<'a, 'a>,
+    },
     /// Apply input filters in sequence until a match is found
     Conditional {
-        component: String,
-        rule_indices: Vec<usize>,
-        rules: &'a [(MatchRule, usize)],
+        original_component: &'a str,
+        route_infos: &'a [RouteInfo],
+        /// All parameters extracted from path template matching
+        params: Params<'a, 'a>,
     },
 }
 
 /// Error type for router operations
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum RouterError {
-    #[error("Invalid glob pattern: {pattern}")]
-    InvalidGlob { pattern: String },
-    #[error("Invalid glob set")]
-    InvalidGlobSet,
+    #[error("Invalid route pattern: {pattern}")]
+    InvalidPattern { pattern: String },
+    #[error("Unknown plugin referenced in route: {0}")]
+    UnknownPlugin(String),
     #[error("No matching rule found for component: {component}")]
     NoMatchingRule { component: String },
     #[error("Failed to extract value from input path: '{0}'")]
     InputPathFailed(JsonPath),
     #[error("Input filter evaluation failed: {message}")]
     InputFilterFailed { message: String },
+    #[error("Component filtering failed: {message}")]
+    ComponentFilterFailed { message: String },
+    #[error("Parameter '{parameter}' not available in pattern '{pattern}'")]
+    MissingParameter { pattern: String, parameter: String },
+    #[error("Failed to insert route for pattern '{path_pattern}': {error}")]
+    RouteInsertionFailed {
+        path_pattern: String,
+        error: matchit::InsertError,
+    },
 }
 
 impl Router {
-    /// Create a new router from routing rules
-    pub fn new(routing_rules: Vec<RoutingRule>) -> error_stack::Result<Self, RouterError> {
-        let mut builder = GlobSetBuilder::new();
-        let mut rules = Vec::new();
+    /// Create a new router from routing configuration
+    pub fn new(
+        routing_config: RoutingConfig,
+        plugin_indices: &HashMap<String, usize>,
+    ) -> error_stack::Result<Self, RouterError> {
+        let mut router = MatchitRouter::new();
 
-        // Build glob patterns and create mapping
-        for (rule_index, rule) in routing_rules.into_iter().enumerate() {
-            for match_rule in rule.match_rule {
-                let pattern = &match_rule.component;
-                let glob = Glob::new(pattern).change_context_lazy(|| RouterError::InvalidGlob {
-                    pattern: pattern.clone(),
-                })?;
-                builder.add(glob);
-                rules.push((match_rule, rule_index));
+        // Process routing configuration and build trie
+        for (path_pattern, route_rules) in &routing_config.routes {
+            let mut route_infos = Vec::new();
+
+            // Create route info for each rule in this path pattern
+            for route_rule in route_rules {
+                let plugin_index = plugin_indices
+                    .get(route_rule.plugin.as_ref())
+                    .copied()
+                    .ok_or_else(|| {
+                        error_stack::report!(RouterError::UnknownPlugin(
+                            route_rule.plugin.to_string()
+                        ))
+                    })?;
+
+                route_infos.push(RouteInfo {
+                    rule: route_rule.clone(),
+                    path_pattern: path_pattern.clone(),
+                    plugin_index,
+                });
             }
+
+            // Insert into trie router
+            router.insert(path_pattern, route_infos).map_err(|error| {
+                error_stack::report!(RouterError::RouteInsertionFailed {
+                    path_pattern: path_pattern.clone(),
+                    error
+                })
+            })?;
         }
 
-        let glob_set = builder
-            .build()
-            .change_context(RouterError::InvalidGlobSet)?;
-
-        Ok(Router { glob_set, rules })
+        Ok(Router {
+            router,
+            routing_config,
+        })
     }
 
     /// Create a step router for a given component string
     pub fn route<'a>(
         &'a self,
-        component: String,
+        component: &'a str,
     ) -> error_stack::Result<ComponentRouter<'a>, RouterError> {
-        let matches = self.glob_set.matches(&component);
+        // Try to match with trie router
+        let matched = self.router.at(component).map_err(|_| {
+            error_stack::report!(RouterError::NoMatchingRule {
+                component: component.to_owned()
+            })
+        })?;
 
-        error_stack::ensure!(
-            !matches.is_empty(),
-            RouterError::NoMatchingRule { component }
-        );
+        let route_infos = matched.value;
+        let params = matched.params;
 
-        if matches.len() == 1 {
-            let (match_rule, target) = &self.rules[matches[0]];
-            if match_rule.input.is_empty() {
-                return Ok(ComponentRouter::Direct(*target));
-            }
+        // Check if we have a single rule with no conditions and no extracted parameters (direct routing)
+        if route_infos.len() == 1 && route_infos[0].rule.conditions.is_empty() {
+            return Ok(ComponentRouter::Direct {
+                route_info: &route_infos[0],
+                params,
+            });
         }
 
         Ok(ComponentRouter::Conditional {
-            component,
-            rule_indices: matches,
-            rules: &self.rules,
+            original_component: component,
+            route_infos,
+            params,
         })
+    }
+
+    /// Find all routes that could match a given plugin and component
+    pub fn find_routes_for(&self, plugin: &str, component: &str) -> Vec<RouteMatch> {
+        let mut matches = Vec::new();
+
+        // Iterate through all routes in the configuration
+        for (path_pattern, route_rules) in &self.routing_config.routes {
+            for route_rule in route_rules {
+                // Check if this route targets our plugin
+                if plugin != route_rule.plugin.as_ref() {
+                    continue;
+                }
+
+                // Try to construct a path that would match this route
+                if let Some(resolved_path) =
+                    self.construct_path_for_component(path_pattern, component)
+                {
+                    // Create a mock RouteInfo to check allow/deny rules
+                    let route_info = RouteInfo {
+                        rule: route_rule.clone(),
+                        path_pattern: path_pattern.clone(),
+                        plugin_index: 0, // Not used for component filtering
+                    };
+
+                    // Check if the component is allowed by this route
+                    if !route_info.is_allowed(component) {
+                        continue;
+                    }
+
+                    matches.push(RouteMatch {
+                        path_pattern: path_pattern.clone(),
+                        resolved_path,
+                        conditions: route_rule.conditions.clone(),
+                        is_conditional: !route_rule.conditions.is_empty(),
+                    });
+                }
+            }
+        }
+
+        matches
+    }
+
+    /// Construct a resolved path for a component given a path pattern
+    fn construct_path_for_component(&self, path_pattern: &str, component: &str) -> Option<String> {
+        // Handle different pattern substitutions
+        // TODO: Improve how we do this substitution.
+        if path_pattern.contains("{component}") {
+            // Simple component substitution
+            let resolved = path_pattern.replace("{component}", component);
+            // Clean up double slashes that might occur if both pattern and component have slashes
+            Some(resolved.replace("//", "/"))
+        } else if path_pattern.contains("{*component}") {
+            // Wildcard component substitution - strip the leading slash from component
+            let component_without_slash = component.strip_prefix('/').unwrap_or(component);
+            Some(path_pattern.replace("{*component}", component_without_slash))
+        } else {
+            // For patterns that don't have component placeholders, we can't construct a path
+            None
+        }
+    }
+}
+
+impl RouteInfo {
+    fn resolve_component(
+        &self,
+        params: &Params<'_, '_>,
+    ) -> error_stack::Result<String, RouterError> {
+        if let Some(component_template) = &self.rule.component {
+            // Replace placeholders in the component pattern with extracted parameters
+            // TODO: this would likely be better done with some kind of templating
+            // such as tinytemplate. We would ideally compile the pattern templates
+            // and then just substitue the params.
+            let mut resolved = component_template.to_string();
+            for (key, value) in params.iter() {
+                let placeholder = format!("{{{key}}}");
+                resolved = resolved.replace(&placeholder, value);
+            }
+            Ok(resolved)
+        } else {
+            // Default behavior: use "component" parameter if available, otherwise full path
+            let component = params.get("component").ok_or_else(|| {
+                error_stack::report!(RouterError::MissingParameter {
+                    pattern: self.path_pattern.clone(),
+                    parameter: "component".to_string()
+                })
+            })?;
+            Ok(format!("/{component}"))
+        }
+    }
+
+    fn evaluate_conditions(&self, input: &ValueRef) -> error_stack::Result<bool, RouterError> {
+        // Apply input conditions
+        for input_condition in &self.rule.conditions {
+            let input_value = input
+                .resolve_json_path(&input_condition.path)
+                .ok_or_else(|| {
+                    error_stack::report!(RouterError::InputPathFailed(input_condition.path.clone()))
+                })?;
+
+            if input_value != input_condition.value {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    fn is_allowed(&self, component: &str) -> bool {
+        if let Some(deny_list) = &self.rule.component_deny {
+            if deny_list.iter().any(|denied| denied.as_ref() == component) {
+                return false;
+            }
+        }
+
+        if let Some(allow_list) = &self.rule.component_allow {
+            if !allow_list
+                .iter()
+                .any(|allowed| allowed.as_ref() == component)
+            {
+                return false;
+            }
+        }
+
+        true
     }
 }
 
 impl<'a> ComponentRouter<'a> {
-    pub fn direct(&self) -> Option<usize> {
-        match self {
-            ComponentRouter::Direct(target) => Some(*target),
-            ComponentRouter::Conditional { .. } => None,
-        }
-    }
-
     /// Resolve the target plugin for this step router.
-    pub fn route_input(&self, input: ValueRef) -> error_stack::Result<usize, RouterError> {
+    ///
+    /// Returns the plugin index and resolved component name.
+    pub fn get_route_and_component(
+        &self,
+        input: ValueRef,
+    ) -> error_stack::Result<(&'_ RouteInfo, String), RouterError> {
         match self {
-            ComponentRouter::Direct(target) => Ok(*target),
+            ComponentRouter::Direct { route_info, params } => {
+                let component_name = route_info.resolve_component(params)?;
+                Ok((route_info, component_name))
+            }
             ComponentRouter::Conditional {
-                component,
-                rule_indices,
-                rules,
+                original_component,
+                route_infos,
+                params,
             } => {
-                'outer: for rule_index in rule_indices {
-                    let (match_rule, target) = &rules[*rule_index];
-                    for input_condition in &match_rule.input {
-                        let input_value = input
-                            .resolve_json_path(&input_condition.path)
-                            .ok_or_else(|| {
-                                error_stack::report!(RouterError::InputPathFailed(
-                                    input_condition.path.clone()
-                                ))
-                            })?;
-
-                        if input_value != input_condition.value {
-                            continue 'outer; // No match, try next rule
-                        }
+                for route_info in route_infos.iter() {
+                    if !route_info.evaluate_conditions(&input)? {
+                        continue; // Condition not met, try next rule
                     }
 
-                    // If we reach here, we have a match.
-                    return Ok(*target);
+                    let component = route_info.resolve_component(params)?;
+                    if !route_info.is_allowed(&component) {
+                        continue; // Component not allowed, try next rule
+                    }
+
+                    return Ok((route_info, component));
                 }
 
                 error_stack::bail!(RouterError::NoMatchingRule {
-                    component: component.clone()
+                    component: original_component.to_string(),
                 })
             }
         }
@@ -155,106 +323,145 @@ impl<'a> ComponentRouter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::routing::rules::{InputCondition, MatchRule, RoutingRule};
+    use crate::routing::rules::{InputCondition, RouteRule, RoutingConfig};
     use serde_json::json;
     use stepflow_core::workflow::JsonPath;
 
-    fn create_test_rules() -> Vec<RoutingRule> {
-        vec![
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/openai/*".to_string(),
-                    input: vec![],
+    fn create_test_config() -> RoutingConfig {
+        let mut routes = std::collections::HashMap::new();
+
+        routes.insert(
+            "/openai/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "openai".into(),
+                component: None,
+            }],
+        );
+
+        routes.insert(
+            "/custom/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![InputCondition {
+                    path: JsonPath::parse("$.model").unwrap(),
+                    value: ValueRef::new(json!("gpt-4")),
                 }],
-                target: "openai".into(),
-            },
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/custom/*".to_string(),
-                    input: vec![InputCondition {
-                        path: JsonPath::parse("$.model").unwrap(),
-                        value: ValueRef::new(json!("gpt-4")),
-                    }],
-                }],
-                target: "custom".into(),
-            },
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/fallback/*".to_string(),
-                    input: vec![],
-                }],
-                target: "fallback".into(),
-            },
-        ]
+                component_allow: None,
+                component_deny: None,
+                plugin: "custom".into(),
+                component: None,
+            }],
+        );
+
+        routes.insert(
+            "/fallback/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "fallback".into(),
+                component: None,
+            }],
+        );
+
+        RoutingConfig { routes }
+    }
+
+    fn create_test_plugin_indices() -> HashMap<String, usize> {
+        let mut plugin_indices = HashMap::new();
+        plugin_indices.insert("openai".to_string(), 0);
+        plugin_indices.insert("custom".to_string(), 1);
+        plugin_indices.insert("fallback".to_string(), 2);
+        plugin_indices
     }
 
     #[test]
     fn test_router_creation() {
-        let rules = create_test_rules();
-        let router = Router::new(rules);
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices);
         assert!(router.is_ok());
     }
 
     #[test]
     fn test_direct_routing() {
-        let rules = create_test_rules();
-        let router = Router::new(rules).unwrap();
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices).unwrap();
 
-        let step_router = router.route("/openai/chat".to_string()).unwrap();
-        match step_router {
-            ComponentRouter::Direct(target) => assert_eq!(target, 0), // First rule index
-            _ => panic!("Expected direct routing"),
-        }
+        let step_router = router.route("/openai/chat").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+
+        assert_eq!(route_info.rule.plugin.as_ref(), "openai"); // Should route to openai plugin
+        assert_eq!(component_name, "/chat"); // Should extract component from path
     }
 
     #[test]
     fn test_conditional_routing() {
-        let rules = create_test_rules();
-        let router = Router::new(rules).unwrap();
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices).unwrap();
 
-        let step_router = router.route("/custom/model".to_string()).unwrap();
-        match step_router {
-            ComponentRouter::Conditional {
-                component,
-                rule_indices,
-                ..
-            } => {
-                assert_eq!(component, "/custom/model");
-                assert!(!rule_indices.is_empty());
-            }
-            _ => panic!("Expected conditional routing"),
-        }
+        let step_router = router.route("/custom/model").unwrap();
+
+        // Test matching condition
+        let input = ValueRef::new(json!({"model": "gpt-4"}));
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "custom"); // Should route to custom plugin
+        assert_eq!(component_name, "/model"); // Should extract component from path
+
+        // Test non-matching condition
+        let input = ValueRef::new(json!({"model": "gpt-3"}));
+        let result = step_router.get_route_and_component(input);
+        assert!(result.is_err()); // Should fail for non-matching condition
     }
 
     #[test]
     fn test_step_router_resolve_direct() {
-        let step_router = ComponentRouter::Direct(0);
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices).unwrap();
+
+        let step_router = router.route("/openai/chat").unwrap();
         let input = ValueRef::new(serde_json::Value::Null);
-        let result = step_router.route_input(input).unwrap();
-        assert_eq!(result, 0);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+
+        assert_eq!(route_info.rule.plugin.as_ref(), "openai"); // Should route to openai plugin
+        assert_eq!(component_name, "/chat");
+        // Also verify plugin index
+        assert_eq!(route_info.plugin_index, 0);
     }
 
     #[test]
     fn test_step_router_resolve_conditional_match() {
         // Create a real router to test conditional resolution
-        let rules = create_test_rules();
-        let router = Router::new(rules).unwrap();
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices).unwrap();
 
-        let step_router = router.route("/custom/model".to_string()).unwrap();
+        let step_router = router.route("/custom/model").unwrap();
         let input = ValueRef::new(json!({"model": "gpt-4"}));
-        let result = step_router.route_input(input).unwrap();
-        assert_eq!(result, 1); // Second rule index
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+
+        assert_eq!(route_info.rule.plugin.as_ref(), "custom"); // Should route to custom plugin
+        assert_eq!(component_name, "/model");
+        // Also verify plugin index
+        assert_eq!(route_info.plugin_index, 1);
     }
 
     #[test]
     fn test_step_router_resolve_conditional_no_match() {
         // Create a real router to test conditional resolution
-        let rules = create_test_rules();
-        let router = Router::new(rules).unwrap();
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices).unwrap();
 
-        let step_router = router.route("/custom/model".to_string()).unwrap();
+        let step_router = router.route("/custom/model").unwrap();
         let input = ValueRef::new(json!({"model": "gpt-3"})); // Doesn't match "gpt-4"
-        let result = step_router.route_input(input);
+        let result = step_router.get_route_and_component(input);
         assert_eq!(
             result.unwrap_err().current_context(),
             &RouterError::NoMatchingRule {
@@ -265,50 +472,58 @@ mod tests {
 
     #[test]
     fn test_path_style_component_matching() {
-        let rules = vec![
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/openai/chat/*".to_string(),
-                    input: vec![],
-                }],
-                target: "openai".into(),
-            },
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/anthropic/*/claude".to_string(),
-                    input: vec![],
-                }],
-                target: "anthropic".into(),
-            },
-        ];
+        let mut routes = std::collections::HashMap::new();
 
-        let router = Router::new(rules).unwrap();
+        routes.insert(
+            "/openai/chat/{subcomponent}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "openai".into(),
+                component: Some("/{subcomponent}".into()),
+            }],
+        );
+
+        routes.insert(
+            "/anthropic/{model}/claude".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "anthropic".into(),
+                component: Some("/{model}".into()),
+            }],
+        );
+
+        let config = RoutingConfig { routes };
+        let mut plugin_indices = HashMap::new();
+        plugin_indices.insert("openai".to_string(), 0);
+        plugin_indices.insert("anthropic".to_string(), 1);
+        let router = Router::new(config, &plugin_indices).unwrap();
 
         // Test OpenAI pattern
-        let step_router = router
-            .route("/openai/chat/completions".to_string())
-            .unwrap();
-        match step_router {
-            ComponentRouter::Direct(target) => assert_eq!(target, 0), // First rule index
-            _ => panic!("Expected direct routing"),
-        }
+        let step_router = router.route("/openai/chat/completions").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "openai"); // Should route to openai plugin
+        assert_eq!(component_name, "/completions"); // Should extract subcomponent parameter
 
         // Test Anthropic pattern
-        let step_router = router
-            .route("/anthropic/models/claude".to_string())
-            .unwrap();
-        match step_router {
-            ComponentRouter::Direct(target) => assert_eq!(target, 1), // Second rule index
-            _ => panic!("Expected direct routing"),
-        }
+        let step_router = router.route("/anthropic/models/claude").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "anthropic"); // Should route to anthropic plugin
+        assert_eq!(component_name, "/models"); // Should extract model parameter
     }
 
     #[test]
     fn test_no_matching_rule() {
-        let rules = create_test_rules();
-        let router = Router::new(rules).unwrap();
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices).unwrap();
 
-        let result = router.route("/unknown/component".to_string());
+        let result = router.route("/unknown/component");
         assert_eq!(
             result.unwrap_err().current_context(),
             &RouterError::NoMatchingRule {
@@ -318,103 +533,246 @@ mod tests {
     }
 
     #[test]
-    fn test_fallback_routing() {
-        let rules = vec![
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/service/*".to_string(),
-                    input: vec![InputCondition {
+    fn test_fallthrough_routing() {
+        let mut routes = std::collections::HashMap::new();
+
+        routes.insert(
+            "/service/{component}".to_string(),
+            vec![
+                RouteRule {
+                    conditions: vec![InputCondition {
                         path: JsonPath::parse("$.priority").unwrap(),
                         value: ValueRef::new(json!("high")),
                     }],
-                }],
-                target: "high_priority".into(),
-            },
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/service/*".to_string(),
-                    input: vec![],
-                }],
-                target: "default".into(),
-            },
-        ];
+                    component_allow: None,
+                    component_deny: None,
+                    plugin: "high_priority".into(),
+                    component: None,
+                },
+                RouteRule {
+                    conditions: vec![],
+                    component_allow: None,
+                    component_deny: None,
+                    plugin: "default".into(),
+                    component: None,
+                },
+            ],
+        );
 
-        let router = Router::new(rules).unwrap();
-        let step_router = router.route("/service/process".to_string()).unwrap();
+        let config = RoutingConfig { routes };
+        let mut plugin_indices = HashMap::new();
+        plugin_indices.insert("high_priority".to_string(), 0);
+        plugin_indices.insert("default".to_string(), 1);
+        let router = Router::new(config, &plugin_indices).unwrap();
+        let step_router = router.route("/service/process").unwrap();
 
-        match &step_router {
-            ComponentRouter::Conditional { rule_indices, .. } => {
-                assert_eq!(rule_indices.len(), 2);
+        // Test high priority match
+        let input = ValueRef::new(json!({"priority": "high"}));
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "high_priority"); // Should route to high priority plugin
+        assert_eq!(component_name, "/process"); // Should extract component parameter
 
-                // Test high priority match
-                let input = ValueRef::new(json!({"priority": "high"}));
-                let result = step_router.route_input(input).unwrap();
-                assert_eq!(result, 0); // First rule index
-
-                // Test fallback match
-                let input = ValueRef::new(json!({"priority": "low"}));
-                let result = step_router.route_input(input).unwrap();
-                assert_eq!(result, 1); // Second rule index (fallback)
-            }
-            _ => panic!("Expected conditional routing"),
-        }
+        // Test fallback match
+        let input = ValueRef::new(json!({"priority": "low"}));
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "default"); // Should route to default plugin
+        assert_eq!(component_name, "/process"); // Should extract component parameter
     }
 
     #[test]
-    fn test_step_router_direct_method() {
-        let step_router_direct = ComponentRouter::Direct(5);
-        assert_eq!(step_router_direct.direct(), Some(5));
+    fn test_routing_behavior_consistency() {
+        // Test that the same route with the same input produces consistent results
+        let config = create_test_config();
+        let plugin_indices = create_test_plugin_indices();
+        let router = Router::new(config, &plugin_indices).unwrap();
 
-        // Create a conditional step router using the real API
-        let rules = create_test_rules();
-        let router = Router::new(rules).unwrap();
-        let step_router_conditional = router.route("/custom/model".to_string()).unwrap();
-        assert_eq!(step_router_conditional.direct(), None);
+        let step_router = router.route("/openai/chat").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+
+        // Route multiple times and ensure consistency
+        let result1 = step_router.get_route_and_component(input.clone()).unwrap();
+        let result2 = step_router.get_route_and_component(input).unwrap();
+
+        assert_eq!(result1.0.rule.plugin, result2.0.rule.plugin);
+        assert_eq!(result1.1, result2.1);
     }
 
     #[test]
     fn test_rule_map_structure() {
-        let rules = vec![
-            RoutingRule {
-                match_rule: vec![
-                    MatchRule {
-                        component: "/pattern1/*".to_string(),
-                        input: vec![],
-                    },
-                    MatchRule {
-                        component: "/pattern2/*".to_string(),
-                        input: vec![],
-                    },
-                ],
-                target: "target1".into(),
-            },
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/pattern3/*".to_string(),
-                    input: vec![],
-                }],
-                target: "target2".into(),
-            },
-        ];
+        let mut routes = std::collections::HashMap::new();
 
-        let router = Router::new(rules).unwrap();
+        routes.insert(
+            "/pattern1/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "target1".into(),
+                component: None,
+            }],
+        );
 
-        // Verify the rules structure
-        assert_eq!(router.rules.len(), 3); // 2 match rules from first rule + 1 from second rule
+        routes.insert(
+            "/pattern2/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "target1".into(),
+                component: None,
+            }],
+        );
+
+        routes.insert(
+            "/pattern3/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "target2".into(),
+                component: None,
+            }],
+        );
+
+        let config = RoutingConfig { routes };
+        let mut plugin_indices = HashMap::new();
+        plugin_indices.insert("target1".to_string(), 0);
+        plugin_indices.insert("target2".to_string(), 1);
+        let router = Router::new(config, &plugin_indices).unwrap();
 
         // Test that different patterns route correctly
-        let step_router1 = router.route("/pattern1/test".to_string()).unwrap();
-        if let ComponentRouter::Direct(target) = step_router1 {
-            assert_eq!(target, 0); // First rule index
-        } else {
-            panic!("Expected direct routing");
-        }
+        let step_router1 = router.route("/pattern1/test").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router1.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "target1"); // Should route to target1 plugin
+        assert_eq!(component_name, "/test"); // Should extract component parameter
 
-        let step_router3 = router.route("/pattern3/test".to_string()).unwrap();
-        if let ComponentRouter::Direct(target) = step_router3 {
-            assert_eq!(target, 1); // Second rule index
-        } else {
-            panic!("Expected direct routing");
-        }
+        let step_router3 = router.route("/pattern3/test").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router3.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "target2"); // Should route to target2 plugin
+        assert_eq!(component_name, "/test"); // Should extract component parameter
+    }
+
+    #[test]
+    fn test_multiple_parameter_extraction() {
+        let mut routes = std::collections::HashMap::new();
+
+        routes.insert(
+            "/api/{version}/{service}/{action}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "api_router".into(),
+                component: Some("{service}_{action}".into()),
+            }],
+        );
+
+        routes.insert(
+            "/ml/{model}/inference/{*path}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "ml_service".into(),
+                component: Some("{model}/inference".into()),
+            }],
+        );
+
+        let config = RoutingConfig { routes };
+        let mut plugin_indices = HashMap::new();
+        plugin_indices.insert("api_router".to_string(), 0);
+        plugin_indices.insert("ml_service".to_string(), 1);
+        let router = Router::new(config, &plugin_indices).unwrap();
+
+        // Test API route with multiple parameters
+        let step_router = router.route("/api/v1/user/create").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "api_router"); // Should route to api_router plugin
+        assert_eq!(component_name, "user_create"); // Should resolve template with parameters
+
+        // Test ML route with catch-all parameter
+        let step_router = router.route("/ml/gpt4/inference/chat/completions").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "ml_service"); // Should route to ml_service plugin
+        assert_eq!(component_name, "gpt4/inference"); // Should resolve template with parameters
+    }
+
+    #[test]
+    fn test_component_resolution_fallback() {
+        let mut routes = std::collections::HashMap::new();
+
+        routes.insert(
+            "/fallback/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "fallback_service".into(),
+                component: None, // No component pattern specified
+            }],
+        );
+
+        routes.insert(
+            "/custom/{name}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "custom_service".into(),
+                component: Some("/{name}".into()), // Use name parameter as component
+            }],
+        );
+
+        let config = RoutingConfig { routes };
+        let mut plugin_indices = HashMap::new();
+        plugin_indices.insert("fallback_service".to_string(), 0);
+        plugin_indices.insert("custom_service".to_string(), 1);
+        let router = Router::new(config, &plugin_indices).unwrap();
+
+        // Test fallback to "component" parameter
+        let step_router = router.route("/fallback/my_component").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "fallback_service"); // Should route to fallback_service plugin
+        assert_eq!(component_name, "/my_component"); // Should extract component parameter
+
+        // Test fallback to available parameter when no component parameter exists
+        let step_router = router.route("/custom/my_name").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "custom_service"); // Should route to custom_service plugin
+        assert_eq!(component_name, "/my_name"); // Should extract name parameter as component
+    }
+
+    #[test]
+    fn test_extracted_params_access() {
+        let mut routes = std::collections::HashMap::new();
+
+        routes.insert(
+            "/service/{version}/{endpoint}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "service".into(),
+                component: Some("/{endpoint}".into()),
+            }],
+        );
+
+        let config = RoutingConfig { routes };
+        let mut plugin_indices = HashMap::new();
+        plugin_indices.insert("service".to_string(), 0);
+        let router = Router::new(config, &plugin_indices).unwrap();
+
+        // Test routing with extracted params
+        let step_router = router.route("/service/v2/users").unwrap();
+        let input = ValueRef::new(serde_json::Value::Null);
+        let (route_info, component_name) = step_router.get_route_and_component(input).unwrap();
+        assert_eq!(route_info.rule.plugin.as_ref(), "service"); // Should route to service plugin
+        assert_eq!(component_name, "/users"); // Should extract endpoint parameter as component
     }
 }

--- a/stepflow-rs/crates/stepflow-plugin/src/routing/rules.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/routing/rules.rs
@@ -11,40 +11,58 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
-use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize};
-use serde_with::{OneOrMany, serde_as};
 use std::borrow::Cow;
+use std::collections::HashMap;
 use stepflow_core::values::ValueRef;
 use stepflow_core::workflow::JsonPath;
 
-/// A single routing rule that matches components and routes them to plugins
-#[serde_as]
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct RoutingRule {
-    /// Matching criteria for this rule.
-    /// Must be one or more rules, any of which must match to route to the target.
-    #[serde(rename = "match")]
-    #[serde_as(as = "OneOrMany<_>")]
-    pub match_rule: Vec<MatchRule>,
-
-    /// Target plugin name to route to.
-    pub target: Cow<'static, str>,
+/// Path-keyed routing configuration
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct RoutingConfig {
+    /// Path-to-routing rules mapping
+    ///
+    /// Keys describe paths. For example "/python/{component}" or "/openai/{component}".
+    /// Placeholders may match a single segment (e.g., "{component}") or multiple segments (e.g., "{*component}").
+    ///
+    /// Value: ordered list of routing rules to apply to that path.
+    ///
+    /// Routes will be applied in the order they are listed, with the first matching rule being used.
+    pub routes: HashMap<String, Vec<RouteRule>>,
 }
 
-/// Match rule with JSON path support for precise input matching
-#[derive(Debug, Clone)]
-pub struct MatchRule {
-    /// Component pattern filter
-    pub component: String,
+/// A single routing rule for a specific path
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct RouteRule {
+    /// Optional input conditions that must match for this rule to apply
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<InputCondition>,
 
-    /// Input data conditions using JSON path expressions.
-    /// All conditions must match for this rule to apply.
-    pub input: Vec<InputCondition>,
+    /// Optional component allowlist - only these components are allowed to match this rule
+    ///
+    /// If omitted, all components are allowed to match.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component_allow: Option<Vec<Cow<'static, str>>>,
+
+    /// Optional component denylist - these components are blocked from matching this rule
+    ///
+    /// If omitted, no components are blocked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component_deny: Option<Vec<Cow<'static, str>>>,
+
+    /// Plugin name to route to
+    pub plugin: Cow<'static, str>,
+
+    /// Component name to pass to the plugin.
+    /// Defaults to `/{component}` if not specified, meaning the extracted component name is used.
+    ///
+    /// May be a pattern referencing path placeholders, e.g., "{component}" or "{*component}".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component: Option<Cow<'static, str>>,
 }
 
 /// JSON path condition for matching specific parts of input data
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct InputCondition {
     /// JSON path expression (e.g., "$.model", "$.config.temperature")
     pub path: JsonPath,
@@ -53,399 +71,173 @@ pub struct InputCondition {
     pub value: ValueRef,
 }
 
-impl Serialize for MatchRule {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // If there is only a component filter, serialize as a string.
-        if self.input.is_empty() {
-            serializer.serialize_str(&self.component)
-        } else {
-            // Otherwise serialize as a struct with component and input
-            let mut state = serializer.serialize_struct("Matcher", 2)?;
-            state.serialize_field("component", &self.component)?;
-            state.serialize_field("input", &self.input)?;
-            state.end()
-        }
-    }
+/// Information about a route match for reverse routing
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct RouteMatch {
+    /// The path pattern that matches this route (e.g., "/builtin/{component}")
+    pub path_pattern: String,
+    /// The resolved path for this specific component (e.g., "/builtin/eval")
+    pub resolved_path: String,
+    /// Input conditions that must be met for this route to be available
+    pub conditions: Vec<InputCondition>,
+    /// Whether this route is conditional (derived from conditions.is_empty())
+    pub is_conditional: bool,
 }
-
-struct MatchRuleVisitor;
-
-impl<'de> serde::de::Visitor<'de> for MatchRuleVisitor {
-    type Value = MatchRule;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a string or a MatchRule struct")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        self.visit_string(v.to_string())
-    }
-
-    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        // If the value is a string, treat it as a component pattern
-        Ok(MatchRule {
-            component: v,
-            input: Vec::new(), // No input filters
-        })
-    }
-
-    fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
-    where
-        A: serde::de::MapAccess<'de>,
-    {
-        // Deserialize as a struct with component and input
-        let mut component = None;
-        let mut input = Vec::new();
-
-        let mut map_access = map;
-        while let Some(key) = map_access.next_key::<String>()? {
-            match key.as_str() {
-                "component" => {
-                    if component.is_some() {
-                        return Err(serde::de::Error::duplicate_field("component"));
-                    }
-                    component = Some(map_access.next_value()?);
-                }
-                "input" => {
-                    input = map_access.next_value()?;
-                }
-                _ => {
-                    return Err(serde::de::Error::unknown_field(
-                        key.as_str(),
-                        &["component", "input"],
-                    ));
-                }
-            }
-        }
-
-        Ok(MatchRule {
-            component: component.ok_or_else(|| serde::de::Error::missing_field("component"))?,
-            input,
-        })
-    }
-}
-
-impl<'de> Deserialize<'de> for MatchRule {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_any(MatchRuleVisitor)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    type RoutingRules = Vec<RoutingRule>;
-
     #[test]
-    fn test_routing_rules_serialization() {
-        let rules = vec![
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/openai/*".to_string(),
-                    input: vec![],
-                }],
-                target: "openai".into(),
-            },
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/custom/*".to_string(),
-                    input: vec![InputCondition {
+    fn test_routing_config_serialization() {
+        let mut routes = HashMap::new();
+        routes.insert(
+            "/openai/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "openai".into(),
+                component: None,
+            }],
+        );
+        routes.insert(
+            "/python/{component}".to_string(),
+            vec![
+                RouteRule {
+                    conditions: vec![InputCondition {
                         path: JsonPath::parse("$.model").unwrap(),
-                        value: ValueRef::new(serde_json::json!("gpt-4")),
+                        value: ValueRef::new(serde_json::json!("llama2")),
                     }],
-                }],
-                target: "custom".into(),
-            },
-        ];
+                    component_allow: None,
+                    component_deny: None,
+                    plugin: "llama2_pool".into(),
+                    component: None,
+                },
+                RouteRule {
+                    conditions: vec![],
+                    component_allow: None,
+                    component_deny: None,
+                    plugin: "default_pool".into(),
+                    component: None,
+                },
+            ],
+        );
 
-        let serialized = serde_json::to_string(&rules).unwrap();
-        assert!(serialized.contains("/openai/*"));
-        assert!(serialized.contains("/custom/*"));
-        assert!(serialized.contains("gpt-4"));
+        let config = RoutingConfig { routes };
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(serialized.contains("/openai/{component}"));
+        assert!(serialized.contains("/python/{component}"));
+        assert!(serialized.contains("llama2"));
     }
 
     #[test]
-    fn test_routing_rules_deserialization() {
+    fn test_routing_config_deserialization() {
         let json_str = r#"
-        [
-            {
-                "match": "/openai/*",
-                "target": "openai"
-            },
-            {
-                "match": {
-                    "component": "/custom/*",
-                    "input": [
-                        {
-                            "path": "$.model",
-                            "value": "gpt-4"
-                        }
-                    ]
-                },
-                "target": "custom"
+        {
+            "routes": {
+                "/openai/{component}": [
+                    {
+                        "plugin": "openai"
+                    }
+                ],
+                "/python/{component}": [
+                    {
+                        "conditions": [
+                            {
+                                "path": "$.model",
+                                "value": "llama2"
+                            }
+                        ],
+                        "plugin": "llama2_pool"
+                    },
+                    {
+                        "plugin": "default_pool"
+                    }
+                ]
             }
-        ]
+        }
         "#;
 
-        let rules: RoutingRules = serde_json::from_str(json_str).unwrap();
-        assert_eq!(rules.len(), 2);
-        assert_eq!(rules[0].match_rule[0].component, "/openai/*");
-        assert_eq!(rules[0].target, "openai");
-        assert_eq!(rules[1].match_rule[0].component, "/custom/*");
-        assert_eq!(rules[1].target, "custom");
-        assert_eq!(rules[1].match_rule[0].input.len(), 1);
-        assert_eq!(
-            rules[1].match_rule[0].input[0].value,
-            ValueRef::new(serde_json::json!("gpt-4"))
-        );
+        let config: RoutingConfig = serde_json::from_str(json_str).unwrap();
+        assert_eq!(config.routes.len(), 2);
+
+        let openai_rules = &config.routes["/openai/{component}"];
+        assert_eq!(openai_rules.len(), 1);
+        assert_eq!(openai_rules[0].plugin, "openai");
+
+        let python_rules = &config.routes["/python/{component}"];
+        assert_eq!(python_rules.len(), 2);
+        assert_eq!(python_rules[0].conditions.len(), 1);
+        assert_eq!(python_rules[0].plugin, "llama2_pool");
+        assert_eq!(python_rules[1].plugin, "default_pool");
     }
 
     #[test]
-    fn test_match_rule_string_serialization() {
-        let match_rule = MatchRule {
-            component: "/openai/*".to_string(),
-            input: vec![],
-        };
-
-        let serialized = serde_json::to_string(&match_rule).unwrap();
-        assert_eq!(serialized, "\"/openai/*\"");
-    }
-
-    #[test]
-    fn test_match_rule_string_deserialization() {
-        let json_str = "\"/openai/*\"";
-        let match_rule: MatchRule = serde_json::from_str(json_str).unwrap();
-        assert_eq!(match_rule.component, "/openai/*");
-        assert!(match_rule.input.is_empty());
-    }
-
-    #[test]
-    fn test_match_rule_struct_serialization() {
-        let match_rule = MatchRule {
-            component: "/custom/*".to_string(),
-            input: vec![
+    fn test_route_rule_with_conditions() {
+        let rule = RouteRule {
+            conditions: vec![
                 InputCondition {
                     path: JsonPath::parse("$.model").unwrap(),
                     value: ValueRef::new(serde_json::json!("gpt-4")),
                 },
                 InputCondition {
-                    path: JsonPath::parse("$.config.temperature").unwrap(),
+                    path: JsonPath::parse("$.temperature").unwrap(),
                     value: ValueRef::new(serde_json::json!(0.7)),
                 },
             ],
+            component_allow: Some(vec!["allowed_component".into()]),
+            component_deny: Some(vec!["denied_component".into()]),
+            plugin: "test_plugin".into(),
+            component: Some("rewritten_component".into()),
         };
 
-        let serialized = serde_json::to_string(&match_rule).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let serialized = serde_json::to_string(&rule).unwrap();
+        let deserialized: RouteRule = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(parsed["component"], "/custom/*");
-        assert_eq!(parsed["input"][0]["path"], "$.model");
-        assert_eq!(parsed["input"][0]["value"], "gpt-4");
-        assert_eq!(parsed["input"][1]["path"], "$.config.temperature");
-        assert_eq!(parsed["input"][1]["value"], 0.7);
+        assert_eq!(deserialized.conditions.len(), 2);
+        assert_eq!(deserialized.component_allow.as_ref().unwrap().len(), 1);
+        assert_eq!(deserialized.component_deny.as_ref().unwrap().len(), 1);
+        assert_eq!(deserialized.plugin, "test_plugin");
     }
 
     #[test]
-    fn test_match_rule_struct_deserialization() {
-        let json_str = r#"
-        {
-            "component": "/custom/*",
-            "input": [
-                {
-                    "path": "$.model",
-                    "value": "gpt-4"
-                },
-                {
-                    "path": "$.config.temperature",
-                    "value": 0.7
-                }
-            ]
-        }
-        "#;
-
-        let match_rule: MatchRule = serde_json::from_str(json_str).unwrap();
-        assert_eq!(match_rule.component, "/custom/*");
-        assert_eq!(match_rule.input.len(), 2);
-        assert_eq!(
-            match_rule.input[0].value,
-            ValueRef::new(serde_json::json!("gpt-4"))
-        );
-        assert_eq!(
-            match_rule.input[1].value,
-            ValueRef::new(serde_json::json!(0.7))
-        );
-    }
-
-    #[test]
-    fn test_routing_rule_with_multiple_match_rules() {
-        let json_str = r#"
-        {
-            "match": [
-                "/openai/*",
-                {
-                    "component": "/custom/*",
-                    "input": [
-                        {
-                            "path": "$.model",
-                            "value": "gpt-4"
-                        }
-                    ]
-                }
-            ],
-            "target": "mixed"
-        }
-        "#;
-
-        let routing_rule: RoutingRule = serde_json::from_str(json_str).unwrap();
-        assert_eq!(routing_rule.match_rule.len(), 2);
-        assert_eq!(routing_rule.match_rule[0].component, "/openai/*");
-        assert!(routing_rule.match_rule[0].input.is_empty());
-        assert_eq!(routing_rule.match_rule[1].component, "/custom/*");
-        assert_eq!(routing_rule.match_rule[1].input.len(), 1);
-        assert_eq!(routing_rule.target, "mixed");
-    }
-
-    #[test]
-    fn test_routing_rule_single_match_rule() {
-        let json_str = r#"
-        {
-            "match": "/openai/*",
-            "target": "openai"
-        }
-        "#;
-
-        let routing_rule: RoutingRule = serde_json::from_str(json_str).unwrap();
-        assert_eq!(routing_rule.match_rule.len(), 1);
-        assert_eq!(routing_rule.match_rule[0].component, "/openai/*");
-        assert_eq!(routing_rule.target, "openai");
-    }
-
-    #[test]
-    fn test_input_filter_serialization() {
-        let filter = InputCondition {
-            path: JsonPath::parse("$.config.model").unwrap(),
-            value: ValueRef::new(serde_json::json!("claude-3-sonnet")),
+    fn test_route_rule_minimal() {
+        let rule = RouteRule {
+            conditions: vec![],
+            component_allow: None,
+            component_deny: None,
+            plugin: "simple_plugin".into(),
+            component: None,
         };
 
-        let serialized = serde_json::to_string(&filter).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let serialized = serde_json::to_string(&rule).unwrap();
+        let deserialized: RouteRule = serde_json::from_str(&serialized).unwrap();
 
-        assert_eq!(parsed["path"], "$.config.model");
-        assert_eq!(parsed["value"], "claude-3-sonnet");
+        assert!(deserialized.conditions.is_empty());
+        assert!(deserialized.component_allow.is_none());
+        assert!(deserialized.component_deny.is_none());
+        assert_eq!(deserialized.plugin, "simple_plugin");
     }
 
     #[test]
-    fn test_input_filter_deserialization() {
-        let json_str = r#"
-        {
-            "path": "$.config.model",
-            "value": "claude-3-sonnet"
-        }
-        "#;
-
-        let filter: InputCondition = serde_json::from_str(json_str).unwrap();
-        assert_eq!(filter.path.to_string(), "$.config.model");
-        assert_eq!(
-            filter.value,
-            ValueRef::new(serde_json::json!("claude-3-sonnet"))
+    fn test_route_serialization_yaml() {
+        let mut routes = HashMap::new();
+        routes.insert(
+            "/mock/{component}".to_string(),
+            vec![RouteRule {
+                conditions: vec![],
+                component_allow: None,
+                component_deny: None,
+                plugin: "mock".into(),
+                component: None,
+            }],
         );
-    }
 
-    #[test]
-    fn test_input_filter_with_complex_values() {
-        let json_str = r#"
-        {
-            "path": "$.config",
-            "value": {
-                "temperature": 0.7,
-                "max_tokens": 100,
-                "enabled": true
-            }
-        }
-        "#;
-
-        let filter: InputCondition = serde_json::from_str(json_str).unwrap();
-        assert_eq!(filter.path.to_string(), "$.config");
-
-        let expected_value = ValueRef::new(serde_json::json!({
-            "temperature": 0.7,
-            "max_tokens": 100,
-            "enabled": true
-        }));
-        assert_eq!(filter.value, expected_value);
-    }
-
-    #[test]
-    fn test_empty_routing_rules() {
-        let rules = RoutingRules::default();
-        assert!(rules.is_empty());
-
-        let serialized = serde_json::to_string(&rules).unwrap();
-        let deserialized: RoutingRules = serde_json::from_str(&serialized).unwrap();
-        assert!(deserialized.is_empty());
-    }
-
-    #[test]
-    fn test_routing_rules_roundtrip() {
-        let original = vec![
-            RoutingRule {
-                match_rule: vec![MatchRule {
-                    component: "/openai/*".to_string(),
-                    input: vec![],
-                }],
-                target: "openai".into(),
-            },
-            RoutingRule {
-                match_rule: vec![
-                    MatchRule {
-                        component: "/custom/*".to_string(),
-                        input: vec![InputCondition {
-                            path: JsonPath::parse("$.model").unwrap(),
-                            value: ValueRef::new(serde_json::json!("gpt-4")),
-                        }],
-                    },
-                    MatchRule {
-                        component: "/fallback/*".to_string(),
-                        input: vec![],
-                    },
-                ],
-                target: "custom".into(),
-            },
-        ];
-
-        let serialized = serde_json::to_string(&original).unwrap();
-        let deserialized: RoutingRules = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(original.len(), deserialized.len());
+        let routes = RoutingConfig { routes };
+        let serialized = serde_yaml_ng::to_string(&routes).unwrap();
         assert_eq!(
-            original[0].match_rule[0].component,
-            deserialized[0].match_rule[0].component
-        );
-        assert_eq!(original[0].target, deserialized[0].target);
-        assert_eq!(
-            original[1].match_rule.len(),
-            deserialized[1].match_rule.len()
-        );
-        assert_eq!(
-            original[1].match_rule[0].component,
-            deserialized[1].match_rule[0].component
-        );
-        assert_eq!(
-            original[1].match_rule[0].input[0].value,
-            deserialized[1].match_rule[0].input[0].value
+            serialized,
+            "routes:\n  /mock/{component}:\n  - plugin: mock\n"
         );
     }
 }

--- a/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
+++ b/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
@@ -158,12 +158,9 @@ async fn test_http_protocol_integration() {
                     // Look for the echo component
                     let echo_component = components
                         .iter()
-                        .find(|c| c.component.path_string().ends_with("/echo"));
+                        .find(|c| c.component.path().ends_with("/echo"));
                     if let Some(echo_info) = echo_component {
-                        println!(
-                            "✓ Found echo component: {}",
-                            echo_info.component.path_string()
-                        );
+                        println!("✓ Found echo component: {}", echo_info.component.path());
 
                         // Test component info
                         let component = &echo_info.component;
@@ -172,7 +169,7 @@ async fn test_http_protocol_integration() {
                             timeout(Duration::from_secs(5), plugin.component_info(component)).await;
                         match info_result {
                             Ok(Ok(info)) => {
-                                println!("✓ Got component info: {}", info.component.path_string());
+                                println!("✓ Got component info: {}", info.component.path());
 
                                 // Test component execution
                                 let input_json = serde_json::json!({

--- a/tests/basic.yaml
+++ b/tests/basic.yaml
@@ -2,7 +2,7 @@ name: Basic Test Workflow
 description: Simple workflow to test the new test command
 steps:
 - id: message_step
-  component: create_messages
+  component: /builtin/create_messages
   input_schema: null
   output_schema: null
   input:

--- a/tests/builtins/blob_test.yaml
+++ b/tests/builtins/blob_test.yaml
@@ -12,7 +12,7 @@ output_schema:
       type: object
 steps:
 - id: put_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:
@@ -21,7 +21,7 @@ steps:
         workflow: input
       path: data
 - id: get_blob
-  component: get_blob
+  component: /builtin/get_blob
   input_schema: null
   output_schema: null
   input:

--- a/tests/builtins/nested_eval.yaml
+++ b/tests/builtins/nested_eval.yaml
@@ -2,7 +2,7 @@ name: nested_eval_test
 description: Test nested flow execution with eval component
 steps:
 - id: nested_flow
-  component: eval
+  component: /builtin/eval
   inputSchema: null
   outputSchema: null
   input:
@@ -11,7 +11,7 @@ steps:
         name: simple_nested
         steps:
         - id: inner_step
-          component: create_messages
+          component: /builtin/create_messages
           input:
             user_prompt: Hello from nested flow
         output:

--- a/tests/builtins/stepflow-config.yml
+++ b/tests/builtins/stepflow-config.yml
@@ -1,6 +1,6 @@
 plugins:
   builtin:
     type: builtin
-routing:
-  - match: "*"
-    target: builtin
+routes:
+  "/builtin/{component}":
+    - plugin: builtin

--- a/tests/mcp/basic_mcp.yaml
+++ b/tests/mcp/basic_mcp.yaml
@@ -1,5 +1,5 @@
 input:
-  message: 
+  message:
     type: string
 
 output:
@@ -8,7 +8,7 @@ output:
 
 steps:
   - id: test_step
-    component: eval
+    component: /builtin/eval
     input:
       expr: '"Testing MCP integration: " + $.input.message'
     output: result

--- a/tests/mock/stepflow-config.yml
+++ b/tests/mock/stepflow-config.yml
@@ -2,7 +2,7 @@ plugins:
   mock:
     type: mock
     components:
-      /mock/one_output:
+      /one_output:
         input_schema:
           type: object
           properties:
@@ -20,7 +20,7 @@ plugins:
           { input: "hello"}:
             outcome: success
             result: {output: world}
-      /mock/two_outputs:
+      /two_outputs:
         input_schema:
           type: object
           properties:
@@ -34,13 +34,13 @@ plugins:
             y:
               type: integer
         behaviors:
-          { input: "b" }: 
+          { input: "b" }:
             outcome: success
             result: {x: 1, y: 2}
           { input: "world"}:
             outcome: success
             result: {x: 2, y: 8}
-      /mock/error:
+      /error:
         input_schema:
           type: object
           properties:
@@ -58,7 +58,7 @@ plugins:
           { mode: "succeed" }:
             outcome: success
             result: {output: "succeeded"}
-      /mock/handle_skip:
+      /handle_skip:
         input_schema:
           type: object
           properties:
@@ -79,6 +79,6 @@ plugins:
           { input: null }:
             outcome: success
             result: {output: received null}
-routing:
-  - match: "/mock/*"
-    target: mock
+routes:
+  "/mock/{component}":
+    - plugin: mock

--- a/tests/no_tests.yaml
+++ b/tests/no_tests.yaml
@@ -3,7 +3,7 @@ description: This workflow has no test section and should be skipped
 
 steps:
   - id: simple_step
-    component: eval
+    component: /builtin/eval
     input:
       expression: '"This workflow has no tests"'
 

--- a/tests/python/blob_integration.yaml
+++ b/tests/python/blob_integration.yaml
@@ -17,13 +17,13 @@ output_schema:
 steps:
   # Step 1: Store initial data as blob using builtin component
   - id: store_original_data
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data: { $from: { workflow: input }, path: user_data }
 
   # Step 2: Create blob for Python function definition
   - id: create_process_data_blob
-    component: put_blob
+    component: /builtin/put_blob
     input:
       data:
         input_schema:
@@ -70,7 +70,7 @@ steps:
 
   # Step 4: Retrieve final processed data using builtin component
   - id: get_final_result
-    component: get_blob
+    component: /builtin/get_blob
     input:
       blob_id: { $from: { step: process_blob_data }, path: processed_blob_id }
 

--- a/tests/python/blob_simple.yaml
+++ b/tests/python/blob_simple.yaml
@@ -16,7 +16,7 @@ output_schema:
       type: object
 steps:
 - id: store_with_builtin
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:
@@ -32,7 +32,7 @@ steps:
       timestamp: 2024-01-01T00:00:00Z
 # Create blob for Python function definition
 - id: create_store_data_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:
@@ -78,7 +78,7 @@ steps:
           workflow: input
         path: number
 - id: retrieve_with_builtin
-  component: get_blob
+  component: /builtin/get_blob
   input_schema: null
   output_schema: null
   input:

--- a/tests/python/stepflow-config.yml
+++ b/tests/python/stepflow-config.yml
@@ -6,8 +6,8 @@ plugins:
     transport: stdio
     command: uv
     args: [--project, "../../sdks/python", run, stepflow_sdk]
-routing:
-  - match: "/python/*"
-    target: python
-  - match: "*"
-    target: builtin
+routes:
+  "/python/{component}":
+    - plugin: python
+  "/builtin/{component}":
+    - plugin: builtin

--- a/tests/python/udf_function.yaml
+++ b/tests/python/udf_function.yaml
@@ -17,7 +17,7 @@ output_schema:
       type: object
 steps:
 - id: create_analyze_scores_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:

--- a/tests/python/udf_simple.yaml
+++ b/tests/python/udf_simple.yaml
@@ -17,7 +17,7 @@ output_schema:
 steps:
 # Create blobs for function definitions
 - id: create_addition_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:
@@ -34,7 +34,7 @@ steps:
         - y
       code: input['x'] + input['y']
 - id: create_multiplication_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:
@@ -51,7 +51,7 @@ steps:
         - y
       code: input['x'] * input['y']
 - id: create_complex_calculation_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:

--- a/tests/python/udf_text_processing.yaml
+++ b/tests/python/udf_text_processing.yaml
@@ -17,7 +17,7 @@ output_schema:
 steps:
 # Create blobs for function definitions
 - id: create_word_analysis_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:
@@ -57,7 +57,7 @@ steps:
             'most_common_words': [{'word': word, 'count': count} for word, count in most_common]
         }
 - id: create_pattern_search_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:
@@ -82,7 +82,7 @@ steps:
         except:
             return []
 - id: create_sentiment_analysis_blob
-  component: put_blob
+  component: /builtin/put_blob
   input_schema: null
   output_schema: null
   input:

--- a/tests/sql-state/stepflow-config.yml
+++ b/tests/sql-state/stepflow-config.yml
@@ -2,7 +2,7 @@ plugins:
   mock:
     type: mock
     components:
-      /mock/identity:
+      /identity:
         input_schema:
           type: object
           properties:
@@ -20,9 +20,9 @@ plugins:
           { value: "Testing" }:
             outcome: success
             result: { result: "Testing" }
-routing:
-  - match: "/mock/*"
-    target: mock
+routes:
+  "/mock/{component}":
+    - plugin: mock
 
 # Use SQLite with in-memory database for testing
 state_store:

--- a/tests/stepflow-config.yml
+++ b/tests/stepflow-config.yml
@@ -1,6 +1,6 @@
 plugins:
   builtin:
     type: builtin
-routing:
-  - match: "*"
-    target: builtin
+routes:
+  "/builtin/{*component}":
+    - plugin: builtin


### PR DESCRIPTION
This allows routing rules to define the component passed to the plugin, allowing `/python/{*component}` to be passed as `/{component}` to the Python plugin, and removes the need to track the "prefix" each plugin was available at (which would be inconsistent if available via multiple routes anyway).

This also allows adds the ability to filter components used in a rule.

This fixes the list of components by applying a reverse routing step to indicate the routes that each component is available at.