### PR TITLE
refactor: Eliminate unsafe blocks for env tests

### DIFF
--- a/stepflow-rs/Cargo.toml
+++ b/stepflow-rs/Cargo.toml
@@ -78,15 +78,15 @@ which = { version = "7.0.3", features = ["tracing"] }
 opt-level = 3
 
 [workspace.lints.rust]
-rust_2018_idioms = "warn"
-nonstandard_style = "warn"
-future_incompatible = "warn"
+rust_2018_idioms = "deny"
+nonstandard_style = "deny"
+future_incompatible = "deny"
 
 [workspace.lints.clippy]
-print_stderr = "warn"
-print_stdout = "warn"
-undocumented_unsafe_blocks = "warn"
-unused_trait_names = "warn"
+print_stderr = "deny"
+print_stdout = "deny"
+undocumented_unsafe_blocks = "deny"
+unused_trait_names = "deny"
 
 [workspace.metadata.cargo-machete]
 ignored = []

--- a/stepflow-rs/crates/stepflow-protocol/src/stdio/recv_message_loop.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/stdio/recv_message_loop.rs
@@ -42,7 +42,8 @@ struct ReceiveMessageLoop {
 
 impl ReceiveMessageLoop {
     fn try_new(launcher: Launcher, outgoing_tx: mpsc::Sender<String>) -> Result<Self> {
-        let mut child = launcher.spawn()?;
+        let env: std::collections::HashMap<String, String> = std::env::vars().collect();
+        let mut child = launcher.spawn(&env)?;
 
         let to_child = child.stdin.take().expect("stdin requested");
         let from_child_stdout = child.stdout.take().expect("stdout requested");


### PR DESCRIPTION
These were using unsafe blocks to mutate the environment for tests. This is unsafe when running the tests concurrently, and can be avoided by passing the environment as a map.