### PR TITLE
fix: registration of UDF component

### DIFF
--- a/sdks/python/src/stepflow_py/main.py
+++ b/sdks/python/src/stepflow_py/main.py
@@ -17,13 +17,9 @@ import argparse
 import asyncio
 
 from stepflow_py.stdio_server import StepflowStdioServer
-from stepflow_py.udf import udf
 
 # Create server instance
 server = StepflowStdioServer()
-
-# Register the UDF component
-server.component(udf)
 
 
 def main():

--- a/sdks/python/src/stepflow_py/server.py
+++ b/sdks/python/src/stepflow_py/server.py
@@ -272,9 +272,9 @@ class StepflowServer:
         # Return a success response (though notifications don't expect responses)
         # Create a dummy InitializeResult for notification response
         # (notifications don't typically expect responses)
-        assert (
-            notification.method == Method.initialized
-        ), "Only '{Method.initialized.value}' is expected as a notification"
+        assert notification.method == Method.initialized, (
+            "Only '{Method.initialized.value}' is expected as a notification"
+        )
 
         result = InitializeResult(server_protocol_version=1)
         self.set_initialized(True)

--- a/sdks/python/src/stepflow_py/server.py
+++ b/sdks/python/src/stepflow_py/server.py
@@ -20,12 +20,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
 from typing import Any, assert_never
-from xml.etree.ElementInclude import include
 
 import msgspec
 
 from stepflow_py.context import StepflowContext
-from stepflow_py.udf import udf
 from stepflow_py.exceptions import (
     ComponentNotFoundError,
     StepflowError,
@@ -51,6 +49,7 @@ from stepflow_py.generated_protocol import (
     Notification,
     RequestId,
 )
+from stepflow_py.udf import udf
 
 
 @dataclass

--- a/sdks/python/tests/test_http_server.py
+++ b/sdks/python/tests/test_http_server.py
@@ -60,9 +60,9 @@ class ServerHelper:
     ):
         """Send a request to the live server."""
         request = self._create_request(method, component, input_data, request_id)
-        assert (
-            self._httpx_client is not None
-        ), "Server not started - call _start_live_server() first"
+        assert self._httpx_client is not None, (
+            "Server not started - call _start_live_server() first"
+        )
         return await self._httpx_client.post(
             f"{self.url}/",
             json=msgspec.to_builtins(request),
@@ -74,9 +74,9 @@ class ServerHelper:
     ):
         """Send a streaming request and return the response stream context manager."""
         request = self._create_request(method, component, input_data, request_id)
-        assert (
-            self._httpx_client is not None
-        ), "Server not started - call _start_live_server() first"
+        assert self._httpx_client is not None, (
+            "Server not started - call _start_live_server() first"
+        )
         return self._httpx_client.stream(
             "POST",
             f"{self.url}/",

--- a/sdks/python/tests/test_http_server.py
+++ b/sdks/python/tests/test_http_server.py
@@ -60,9 +60,9 @@ class ServerHelper:
     ):
         """Send a request to the live server."""
         request = self._create_request(method, component, input_data, request_id)
-        assert self._httpx_client is not None, (
-            "Server not started - call _start_live_server() first"
-        )
+        assert (
+            self._httpx_client is not None
+        ), "Server not started - call _start_live_server() first"
         return await self._httpx_client.post(
             f"{self.url}/",
             json=msgspec.to_builtins(request),
@@ -74,9 +74,9 @@ class ServerHelper:
     ):
         """Send a streaming request and return the response stream context manager."""
         request = self._create_request(method, component, input_data, request_id)
-        assert self._httpx_client is not None, (
-            "Server not started - call _start_live_server() first"
-        )
+        assert (
+            self._httpx_client is not None
+        ), "Server not started - call _start_live_server() first"
         return self._httpx_client.stream(
             "POST",
             f"{self.url}/",
@@ -451,12 +451,13 @@ async def test_components_list(test_server):
     assert "result" in result
 
     components = result["result"]["components"]
-    assert len(components) == 2
+    assert len(components) == 3
 
     # Find our test components
     component_names = [comp["component"] for comp in components]
     assert "/simple_component" in component_names
     assert "/context_component" in component_names
+    assert "/udf" in component_names
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_server.py
+++ b/sdks/python/tests/test_server.py
@@ -116,15 +116,22 @@ def test_list_components(server):
         return ValidOutput(greeting="", age_next_year=0)
 
     components = server.get_components()
-    assert len(components) == 2
+    assert len(components) == 3
     assert "/component1" in components
     assert "/component2" in components
+    assert "/udf" in components
 
-    for name, component in components.items():
-        assert isinstance(component, ComponentEntry)
-        assert component.name == name
-        assert component.input_type == ValidInput
-        assert component.output_type == ValidOutput
+    component1 = components["/component1"]
+    assert isinstance(component1, ComponentEntry)
+    assert component1.name == "/component1"
+    assert component1.input_type == ValidInput
+    assert component1.output_type == ValidOutput
+
+    component2 = components["/component2"]
+    assert isinstance(component2, ComponentEntry)
+    assert component2.name == "/component2"
+    assert component2.input_type == ValidInput
+    assert component2.output_type == ValidOutput
 
 
 def test_initialization_state(server):
@@ -252,10 +259,11 @@ async def test_handle_list_components(server):
     response = await server.handle_message(request)
     assert response.id == request.id
     assert hasattr(response, "result")
-    assert len(response.result.components) == 2
+    assert len(response.result.components) == 3
     component_urls = [comp.component for comp in response.result.components]
     assert "/component1" in component_urls
     assert "/component2" in component_urls
+    assert "/udf" in component_urls
 
 
 @pytest.mark.asyncio
@@ -444,9 +452,9 @@ def test_requires_context():
         assert isinstance(request, MethodRequest)
         actual = server.requires_context(request)
         expected = test_case["expected"]
-        assert actual == expected, (
-            f"{test_case['name']}: got {actual}, expected {expected}"
-        )
+        assert (
+            actual == expected
+        ), f"{test_case['name']}: got {actual}, expected {expected}"
 
 
 def test_component_context_detection():

--- a/sdks/python/tests/test_server.py
+++ b/sdks/python/tests/test_server.py
@@ -452,9 +452,9 @@ def test_requires_context():
         assert isinstance(request, MethodRequest)
         actual = server.requires_context(request)
         expected = test_case["expected"]
-        assert (
-            actual == expected
-        ), f"{test_case['name']}: got {actual}, expected {expected}"
+        assert actual == expected, (
+            f"{test_case['name']}: got {actual}, expected {expected}"
+        )
 
 
 def test_component_context_detection():


### PR DESCRIPTION
Previously, it was only registered in the `main` method, so other ways of creating servers (and non-stdio servers) were not having the UDF component registered.