### PR TITLE
fix(py): decorator should preserve iscoroutine property

### DIFF
--- a/sdks/python/src/stepflow_py/__init__.py
+++ b/sdks/python/src/stepflow_py/__init__.py
@@ -31,6 +31,7 @@ from .value import JsonPath, StepReference, Valuable, Value, WorkflowInput
 
 __all__ = [
     # Core classes
+    "StepflowServer",
     "StepflowStdioServer",
     "StepflowContext",
     "FlowBuilder",

--- a/sdks/python/src/stepflow_py/__init__.py
+++ b/sdks/python/src/stepflow_py/__init__.py
@@ -25,6 +25,7 @@ from .generated_protocol import (
     OnSkipSkip,
     SkipAction,
 )
+from .server import StepflowServer
 from .stdio_server import StepflowStdioServer
 from .value import JsonPath, StepReference, Valuable, Value, WorkflowInput
 

--- a/sdks/python/src/stepflow_py/server.py
+++ b/sdks/python/src/stepflow_py/server.py
@@ -15,12 +15,11 @@
 
 from __future__ import annotations
 
-from asyncio import iscoroutinefunction
 import inspect
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import wraps
-import sys
 from typing import Any, assert_never
 
 import msgspec
@@ -283,9 +282,9 @@ class StepflowServer:
         # Return a success response (though notifications don't expect responses)
         # Create a dummy InitializeResult for notification response
         # (notifications don't typically expect responses)
-        assert (
-            notification.method == Method.initialized
-        ), "Only '{Method.initialized.value}' is expected as a notification"
+        assert notification.method == Method.initialized, (
+            "Only '{Method.initialized.value}' is expected as a notification"
+        )
 
         self.set_initialized(True)
 
@@ -362,7 +361,8 @@ class StepflowServer:
 
             result = ComponentExecuteResult(output=output)
             print(
-                f"Executed component {params.component} with input {input_value} produced {output}",
+                f"Executed component {params.component} "
+                "with input {input_value} produced {output}",
                 file=sys.stderr,
             )
             return MethodSuccess(jsonrpc="2.0", id=request.id, result=result)

--- a/sdks/python/tests/test_server.py
+++ b/sdks/python/tests/test_server.py
@@ -23,10 +23,10 @@ This test file focuses on testing the core server functionality:
 """
 
 import inspect
+
 import msgspec
 import pytest
 
-from stepflow_py.stdio_server import StepflowStdioServer
 from stepflow_py import StepflowContext
 from stepflow_py.generated_protocol import (
     ComponentExecuteParams,
@@ -37,6 +37,7 @@ from stepflow_py.generated_protocol import (
     MethodRequest,
 )
 from stepflow_py.server import ComponentEntry, StepflowServer
+from stepflow_py.stdio_server import StepflowStdioServer
 
 
 # Test message classes
@@ -452,9 +453,9 @@ def test_requires_context():
         assert isinstance(request, MethodRequest)
         actual = server.requires_context(request)
         expected = test_case["expected"]
-        assert (
-            actual == expected
-        ), f"{test_case['name']}: got {actual}, expected {expected}"
+        assert actual == expected, (
+            f"{test_case['name']}: got {actual}, expected {expected}"
+        )
 
 
 def test_component_context_detection():

--- a/sdks/python/tests/test_server.py
+++ b/sdks/python/tests/test_server.py
@@ -22,9 +22,11 @@ This test file focuses on testing the core server functionality:
 - Component execution with/without context
 """
 
+import inspect
 import msgspec
 import pytest
 
+from stepflow_py.stdio_server import StepflowStdioServer
 from stepflow_py import StepflowContext
 from stepflow_py.generated_protocol import (
     ComponentExecuteParams,
@@ -450,9 +452,9 @@ def test_requires_context():
         assert isinstance(request, MethodRequest)
         actual = server.requires_context(request)
         expected = test_case["expected"]
-        assert actual == expected, (
-            f"{test_case['name']}: got {actual}, expected {expected}"
-        )
+        assert (
+            actual == expected
+        ), f"{test_case['name']}: got {actual}, expected {expected}"
 
 
 def test_component_context_detection():
@@ -488,3 +490,51 @@ def test_component_context_detection():
 
     assert not getattr(no_context_func, "_expects_context", False)
     assert getattr(with_context_func, "_expects_context", False)
+
+
+@pytest.mark.asyncio
+async def test_decorator_sync():
+    server = StepflowServer()
+
+    @server.component
+    def sync_component(input: ValidInput) -> ValidOutput:
+        return ValidOutput(
+            greeting=f"Sync Hello {input.name}!", age_next_year=input.age + 1
+        )
+
+    component = server.get_component("/sync_component")
+    assert component is not None
+    result = component.function(ValidInput(name="Bob", age=30))
+    assert isinstance(result, ValidOutput)
+    assert result.greeting == "Sync Hello Bob!"
+    assert result.age_next_year == 31
+
+
+@pytest.mark.asyncio
+async def test_decorator_async():
+    server = StepflowStdioServer()
+
+    @server.component
+    async def async_component(input: ValidInput) -> ValidOutput:
+        return ValidOutput(
+            greeting=f"Sync Hello {input.name}!", age_next_year=input.age + 1
+        )
+
+    component = server.get_component("/async_component")
+    assert component is not None
+    assert inspect.iscoroutinefunction(component.function)
+    result = await component.function(ValidInput(name="Bob", age=30))
+    assert isinstance(result, ValidOutput)
+    assert result.greeting == "Sync Hello Bob!"
+    assert result.age_next_year == 31
+
+    server2 = StepflowServer()
+    server2.component(async_component, name="async_component2")
+
+    component2 = server2.get_component("/async_component2")
+    assert component2 is not None
+    assert inspect.iscoroutinefunction(component2.function)
+    result2 = await component2.function(ValidInput(name="Bob", age=30))
+    assert isinstance(result2, ValidOutput)
+    assert result2.greeting == "Sync Hello Bob!"
+    assert result2.age_next_year == 31


### PR DESCRIPTION
This ensures that re-wrapping a decorated function retains its coroutine nature.