### PR TITLE
feat: add extensible metadata to flows and steps

### DIFF
--- a/docs/docs/protocol/errors.md
+++ b/docs/docs/protocol/errors.md
@@ -57,3 +57,4 @@ The protocol defines error codes in standardized ranges following JSON-RPC conve
 | -32008 | Blob Not Found | Requested blob does not exist | Invalid blob ID |
 | -32009 | Expression Evaluation Failed | Flow expression could not be evaluated | Invalid reference or path |
 | -32010 | Session Expired | HTTP session has expired | Session cleanup or timeout |
+| -32011 | Invalid Step ID | Provided step ID does not exist | Unknown step ID in a request |

--- a/docs/docs/protocol/errors.md
+++ b/docs/docs/protocol/errors.md
@@ -57,4 +57,5 @@ The protocol defines error codes in standardized ranges following JSON-RPC conve
 | -32008 | Blob Not Found | Requested blob does not exist | Invalid blob ID |
 | -32009 | Expression Evaluation Failed | Flow expression could not be evaluated | Invalid reference or path |
 | -32010 | Session Expired | HTTP session has expired | Session cleanup or timeout |
-| -32011 | Invalid Step ID | Provided step ID does not exist | Unknown step ID in a request |
+| -32011 | Invalid Value | Invalid value for a field | Value in a field is not valid |
+| -32012 | Not found | Referenced value is not found | Referenced entity does not exist |

--- a/schemas/flow.json
+++ b/schemas/flow.json
@@ -83,6 +83,11 @@
             "$ref": "#/$defs/ExampleInput"
           }
         },
+        "metadata": {
+          "description": "Extensible metadata for the flow that can be used by tools and frameworks.",
+          "type": "object",
+          "additionalProperties": true
+        },
         "schema": {
           "type": "string",
           "const": "https://stepflow.org/schemas/v1/flow.json"
@@ -152,6 +157,11 @@
         "input": {
           "description": "Arguments to pass to the component for this step",
           "$ref": "#/$defs/ValueTemplate"
+        },
+        "metadata": {
+          "description": "Extensible metadata for the step that can be used by tools and frameworks.",
+          "type": "object",
+          "additionalProperties": true
         }
       },
       "required": [

--- a/schemas/protocol.json
+++ b/schemas/protocol.json
@@ -56,6 +56,9 @@
             },
             {
               "$ref": "#/$defs/EvaluateFlowParams"
+            },
+            {
+              "$ref": "#/$defs/GetFlowMetadataParams"
             }
           ]
         }
@@ -94,7 +97,8 @@
         "components/execute",
         "blobs/put",
         "blobs/get",
-        "flows/evaluate"
+        "flows/evaluate",
+        "flows/get_metadata"
       ]
     },
     "InitializeParams": {
@@ -123,11 +127,26 @@
         "input": {
           "description": "The input to the component.",
           "$ref": "#/$defs/Value"
+        },
+        "step_id": {
+          "description": "The ID of the step being executed.",
+          "type": "string"
+        },
+        "run_id": {
+          "description": "The ID of the workflow run.",
+          "type": "string"
+        },
+        "flow_id": {
+          "description": "The ID of the flow being executed.",
+          "$ref": "#/$defs/BlobId"
         }
       },
       "required": [
         "component",
-        "input"
+        "input",
+        "step_id",
+        "run_id",
+        "flow_id"
       ]
     },
     "Component": {
@@ -141,6 +160,10 @@
     },
     "Value": {
       "description": "Any JSON value (object, array, string, number, boolean, or null)"
+    },
+    "BlobId": {
+      "description": "A SHA-256 hash of the blob content, represented as a hexadecimal string.",
+      "type": "string"
     },
     "ComponentInfoParams": {
       "description": "Sent from Stepflow to the component server to request information about a specific component.",
@@ -171,10 +194,6 @@
       "required": [
         "blob_id"
       ]
-    },
-    "BlobId": {
-      "description": "A SHA-256 hash of the blob content, represented as a hexadecimal string.",
-      "type": "string"
     },
     "PutBlobParams": {
       "description": "Sent from the component server to the Stepflow to store a blob with the provided content.",
@@ -217,6 +236,37 @@
         "flow_id",
         "input"
       ]
+    },
+    "GetFlowMetadataParams": {
+      "description": "Sent from the component server to Stepflow to get flow and step metadata.\n\nThis request allows components to access workflow-level metadata and step-specific metadata\nduring execution. The metadata can contain arbitrary JSON values defined in the workflow\nYAML/JSON.",
+      "type": "object",
+      "properties": {
+        "step_id": {
+          "description": "The ID of the step to get metadata for (optional).\n\nIf not provided, only flow-level metadata is returned.\nIf provided, both flow metadata and the specified step's metadata are returned.\nIf the step_id doesn't exist, step_metadata will be None in the response.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_id": {
+          "description": "The execution run ID for the current workflow execution.\n\nThis allows the handler to construct the proper execution context for metadata lookup.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "flow_id": {
+          "description": "The flow blob ID for the current workflow.\n\nThis allows the handler to construct the proper execution context for metadata lookup.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BlobId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     },
     "MethodResponse": {
       "description": "Response to a method request.",
@@ -264,6 +314,9 @@
             },
             {
               "$ref": "#/$defs/EvaluateFlowResult"
+            },
+            {
+              "$ref": "#/$defs/GetFlowMetadataResult"
             }
           ]
         }
@@ -513,6 +566,28 @@
       "required": [
         "outcome",
         "error"
+      ]
+    },
+    "GetFlowMetadataResult": {
+      "description": "Sent from Stepflow back to the component server with the requested metadata.\n\nContains the flow metadata and step metadata if a specific step was requested.\nThe metadata values are arbitrary JSON objects that can be accessed by components during\nworkflow execution.",
+      "type": "object",
+      "properties": {
+        "flow_metadata": {
+          "description": "Metadata for the current flow.\n\nThis always contains the flow-level metadata defined in the workflow file.\nCommon fields include name, description, version, but can contain any\narbitrary JSON structure defined by the workflow author.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "step_metadata": {
+          "description": "Metadata for the specified step (only present if step_id was provided and found).\n\nThis contains step-specific metadata defined in the workflow file.\nWill be None if no step_id was provided in the request",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "flow_metadata"
       ]
     },
     "MethodError": {

--- a/schemas/protocol.json
+++ b/schemas/protocol.json
@@ -241,32 +241,21 @@
       "description": "Sent from the component server to Stepflow to get flow and step metadata.\n\nThis request allows components to access workflow-level metadata and step-specific metadata\nduring execution. The metadata can contain arbitrary JSON values defined in the workflow\nYAML/JSON.",
       "type": "object",
       "properties": {
+        "flow_id": {
+          "description": "The flow to retrieve metadata for.",
+          "$ref": "#/$defs/BlobId"
+        },
         "step_id": {
           "description": "The ID of the step to get metadata for (optional).\n\nIf not provided, only flow-level metadata is returned.\nIf provided, both flow metadata and the specified step's metadata are returned.\nIf the step_id doesn't exist, step_metadata will be None in the response.",
           "type": [
             "string",
             "null"
           ]
-        },
-        "run_id": {
-          "description": "The execution run ID for the current workflow execution.\n\nThis allows the handler to construct the proper execution context for metadata lookup.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "flow_id": {
-          "description": "The flow blob ID for the current workflow.\n\nThis allows the handler to construct the proper execution context for metadata lookup.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/BlobId"
-            },
-            {
-              "type": "null"
-            }
-          ]
         }
-      }
+      },
+      "required": [
+        "flow_id"
+      ]
     },
     "MethodResponse": {
       "description": "Response to a method request.",

--- a/sdks/python/src/stepflow_py/context.py
+++ b/sdks/python/src/stepflow_py/context.py
@@ -98,9 +98,9 @@ class StepflowContext:
         # Extract the result from the response message
         if isinstance(response_message, MethodSuccess):
             result = response_message.result
-            assert isinstance(
-                result, result_type
-            ), f"Expected {result_type}, got {type(result)}"
+            assert isinstance(result, result_type), (
+                f"Expected {result_type}, got {type(result)}"
+            )
             return result
         elif isinstance(response_message, MethodError):
             # Handle error case

--- a/sdks/python/src/stepflow_py/context.py
+++ b/sdks/python/src/stepflow_py/context.py
@@ -98,9 +98,9 @@ class StepflowContext:
         # Extract the result from the response message
         if isinstance(response_message, MethodSuccess):
             result = response_message.result
-            assert isinstance(result, result_type), (
-                f"Expected {result_type}, got {type(result)}"
-            )
+            assert isinstance(
+                result, result_type
+            ), f"Expected {result_type}, got {type(result)}"
             return result
         elif isinstance(response_message, MethodError):
             # Handle error case
@@ -241,9 +241,9 @@ class StepflowContext:
         # Use provided step_id, or fall back to current step_id, or None
         target_step_id = step_id or self._step_id
 
+        assert self._flow_id is not None, "flow_id is not available in context"
         params = GetFlowMetadataParams(
             step_id=target_step_id,
-            run_id=self._run_id,
             flow_id=self._flow_id,
         )
         response = await self._send_request(

--- a/sdks/python/src/stepflow_py/flow_builder.py
+++ b/sdks/python/src/stepflow_py/flow_builder.py
@@ -119,10 +119,12 @@ class FlowBuilder:
         name: str | None = None,
         description: str | None = None,
         version: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ):
         self.name = name
         self.description = description
         self.version = version
+        self.metadata = metadata or {}
         self.input_schema: Schema | None = None
         self.output_schema: Schema | None = None
         self.steps: dict[str, Step] = {}
@@ -141,7 +143,10 @@ class FlowBuilder:
             step_refs = builder.step("step_name").get_references()
         """
         builder = cls(
-            name=flow.name, description=flow.description, version=flow.version
+            name=flow.name,
+            description=flow.description,
+            version=flow.version,
+            metadata=flow.metadata,
         )
         builder.input_schema = flow.inputSchema
         builder.output_schema = flow.outputSchema
@@ -176,6 +181,11 @@ class FlowBuilder:
             self.output_schema = schema
         return self
 
+    def set_metadata(self, metadata: dict[str, Any]) -> FlowBuilder:
+        """Set the metadata for the flow."""
+        self.metadata = metadata
+        return self
+
     def add_step(
         self,
         *,
@@ -186,6 +196,7 @@ class FlowBuilder:
         output_schema: dict[str, Any] | Schema | None = None,
         skip_if: StepReference | WorkflowInput | Value | None = None,
         on_error: ErrorAction | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> StepHandle:
         """Add a step to the flow."""
         # Component is now just a string, no conversion needed
@@ -235,6 +246,7 @@ class FlowBuilder:
             outputSchema=output_schema_obj,
             skipIf=skip_if_expr,
             onError=on_error_action,
+            metadata=metadata or {},
         )
 
         self.steps[id] = step
@@ -267,6 +279,7 @@ class FlowBuilder:
             outputSchema=self.output_schema,
             steps=list(self.steps.values()),
             output=self._output,
+            metadata=self.metadata,
         )
 
     def _convert_to_value_template(self, data: Valuable) -> ValueTemplate | None:

--- a/sdks/python/src/stepflow_py/generated_flow.py
+++ b/sdks/python/src/stepflow_py/generated_flow.py
@@ -351,6 +351,15 @@ class Step(Struct, kw_only=True):
         ]
         | None
     ) = None
+    metadata: (
+        Annotated[
+            Dict[str, Any],
+            Meta(
+                description='Extensible metadata for the step that can be used by tools and frameworks.'
+            ),
+        ]
+        | None
+    ) = None
 
 
 class FlowV1(Struct, kw_only=True):
@@ -391,6 +400,15 @@ class FlowV1(Struct, kw_only=True):
             List[ExampleInput],
             Meta(
                 description='Example inputs for the workflow that can be used for testing and UI dropdowns.'
+            ),
+        ]
+        | None
+    ) = None
+    metadata: (
+        Annotated[
+            Dict[str, Any],
+            Meta(
+                description='Extensible metadata for the flow that can be used by tools and frameworks.'
             ),
         ]
         | None

--- a/sdks/python/src/stepflow_py/generated_protocol.py
+++ b/sdks/python/src/stepflow_py/generated_protocol.py
@@ -112,29 +112,12 @@ class EvaluateFlowParams(Struct, kw_only=True):
 
 
 class GetFlowMetadataParams(Struct, kw_only=True):
+    flow_id: Annotated[BlobId, Meta(description='The flow to retrieve metadata for.')]
     step_id: (
         Annotated[
             str | None,
             Meta(
                 description="The ID of the step to get metadata for (optional).\n\nIf not provided, only flow-level metadata is returned.\nIf provided, both flow metadata and the specified step's metadata are returned.\nIf the step_id doesn't exist, step_metadata will be None in the response."
-            ),
-        ]
-        | None
-    ) = None
-    run_id: (
-        Annotated[
-            str | None,
-            Meta(
-                description='The execution run ID for the current workflow execution.\n\nThis allows the handler to construct the proper execution context for metadata lookup.'
-            ),
-        ]
-        | None
-    ) = None
-    flow_id: (
-        Annotated[
-            BlobId | None,
-            Meta(
-                description='The flow blob ID for the current workflow.\n\nThis allows the handler to construct the proper execution context for metadata lookup.'
             ),
         ]
         | None

--- a/sdks/python/src/stepflow_py/generated_protocol.py
+++ b/sdks/python/src/stepflow_py/generated_protocol.py
@@ -20,7 +20,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Annotated, Any, ClassVar, List, Literal
+from typing import Annotated, Any, ClassVar, Dict, List, Literal
 
 from msgspec import Meta, Struct
 
@@ -46,6 +46,7 @@ class Method(Enum):
     blobs_put = 'blobs/put'
     blobs_get = 'blobs/get'
     flows_evaluate = 'flows/evaluate'
+    flows_get_metadata = 'flows/get_metadata'
 
 
 class InitializeParams(Struct, kw_only=True):
@@ -75,6 +76,14 @@ Value = Annotated[
 ]
 
 
+BlobId = Annotated[
+    str,
+    Meta(
+        description='A SHA-256 hash of the blob content, represented as a hexadecimal string.'
+    ),
+]
+
+
 class ComponentInfoParams(Struct, kw_only=True):
     component: Annotated[
         Component, Meta(description='The component to get information about.')
@@ -85,12 +94,8 @@ class ComponentListParams(Struct, kw_only=True):
     pass
 
 
-BlobId = Annotated[
-    str,
-    Meta(
-        description='A SHA-256 hash of the blob content, represented as a hexadecimal string.'
-    ),
-]
+class GetBlobParams(Struct, kw_only=True):
+    blob_id: Annotated[BlobId, Meta(description='The ID of the blob to retrieve.')]
 
 
 class BlobType(Enum):
@@ -104,6 +109,36 @@ class EvaluateFlowParams(Struct, kw_only=True):
         Meta(description='The ID of the flow to evaluate (blob ID of the flow).'),
     ]
     input: Annotated[Value, Meta(description='The input to provide to the flow.')]
+
+
+class GetFlowMetadataParams(Struct, kw_only=True):
+    step_id: (
+        Annotated[
+            str | None,
+            Meta(
+                description="The ID of the step to get metadata for (optional).\n\nIf not provided, only flow-level metadata is returned.\nIf provided, both flow metadata and the specified step's metadata are returned.\nIf the step_id doesn't exist, step_metadata will be None in the response."
+            ),
+        ]
+        | None
+    ) = None
+    run_id: (
+        Annotated[
+            str | None,
+            Meta(
+                description='The execution run ID for the current workflow execution.\n\nThis allows the handler to construct the proper execution context for metadata lookup.'
+            ),
+        ]
+        | None
+    ) = None
+    flow_id: (
+        Annotated[
+            BlobId | None,
+            Meta(
+                description='The flow blob ID for the current workflow.\n\nThis allows the handler to construct the proper execution context for metadata lookup.'
+            ),
+        ]
+        | None
+    ) = None
 
 
 class InitializeResult(Struct, kw_only=True):
@@ -153,6 +188,24 @@ class FlowResultFailed(Struct, kw_only=True, tag_field='outcome', tag='failed'):
     error: FlowError
 
 
+class GetFlowMetadataResult(Struct, kw_only=True):
+    flow_metadata: Annotated[
+        Dict[str, Any],
+        Meta(
+            description='Metadata for the current flow.\n\nThis always contains the flow-level metadata defined in the workflow file.\nCommon fields include name, description, version, but can contain any\narbitrary JSON structure defined by the workflow author.'
+        ),
+    ]
+    step_metadata: (
+        Annotated[
+            Dict[str, Any] | None,
+            Meta(
+                description='Metadata for the specified step (only present if step_id was provided and found).\n\nThis contains step-specific metadata defined in the workflow file.\nWill be None if no step_id was provided in the request'
+            ),
+        ]
+        | None
+    ) = None
+
+
 class Error(Struct, kw_only=True):
     code: Annotated[int, Meta(description='A numeric code indicating the error type.')]
     message: Annotated[
@@ -176,10 +229,9 @@ class Initialized(Struct, kw_only=True):
 class ComponentExecuteParams(Struct, kw_only=True):
     component: Annotated[Component, Meta(description='The component to execute.')]
     input: Annotated[Value, Meta(description='The input to the component.')]
-
-
-class GetBlobParams(Struct, kw_only=True):
-    blob_id: Annotated[BlobId, Meta(description='The ID of the blob to retrieve.')]
+    step_id: Annotated[str, Meta(description='The ID of the step being executed.')]
+    run_id: Annotated[str, Meta(description='The ID of the workflow run.')]
+    flow_id: Annotated[BlobId, Meta(description='The ID of the flow being executed.')]
 
 
 class PutBlobParams(Struct, kw_only=True):
@@ -257,7 +309,8 @@ class MethodRequest(Struct, kw_only=True):
         | ComponentListParams
         | GetBlobParams
         | PutBlobParams
-        | EvaluateFlowParams,
+        | EvaluateFlowParams
+        | GetFlowMetadataParams,
         Meta(
             description='The parameters for the method call. Set on method requests.',
             title='MethodParams',
@@ -285,7 +338,8 @@ class MethodSuccess(Struct, kw_only=True):
         | ListComponentsResult
         | GetBlobResult
         | PutBlobResult
-        | EvaluateFlowResult,
+        | EvaluateFlowResult
+        | GetFlowMetadataResult,
         Meta(
             description='The result of a successful method execution.',
             title='MethodResult',

--- a/sdks/python/src/stepflow_py/message_decoder.py
+++ b/sdks/python/src/stepflow_py/message_decoder.py
@@ -36,6 +36,8 @@ from .generated_protocol import (
     EvaluateFlowResult,
     GetBlobParams,
     GetBlobResult,
+    GetFlowMetadataParams,
+    GetFlowMetadataResult,
     Initialized,
     InitializeParams,
     InitializeResult,
@@ -222,6 +224,8 @@ def _decode_params_for_method(method: Method, params_raw: Raw):
         return msgspec.json.decode(params_raw, type=PutBlobParams)
     elif method == Method.flows_evaluate:
         return msgspec.json.decode(params_raw, type=EvaluateFlowParams)
+    elif method == Method.flows_get_metadata:
+        return msgspec.json.decode(params_raw, type=GetFlowMetadataParams)
     else:
         raise StepflowProtocolError(f"Unknown method: {method.value}")
 
@@ -242,5 +246,7 @@ def _get_result_type_for_method(method: Method) -> type:
         return PutBlobResult
     elif method == Method.flows_evaluate:
         return EvaluateFlowResult
+    elif method == Method.flows_get_metadata:
+        return GetFlowMetadataResult
     else:
         raise StepflowProtocolError(f"Unknown method: {method.value}")

--- a/sdks/python/tests/test_http_server.py
+++ b/sdks/python/tests/test_http_server.py
@@ -197,6 +197,9 @@ class ServerHelper:
                 params=ComponentExecuteParams(
                     component=component or "/simple_component",
                     input=input_data or {"message": "test"},
+                    step_id="test_step",
+                    run_id="test-run-id",
+                    flow_id="test-flow-id",
                 ),
             )
         else:

--- a/sdks/python/tests/test_server.py
+++ b/sdks/python/tests/test_server.py
@@ -215,7 +215,11 @@ async def test_handle_component_execute(server):
         id="test-1",
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="/test_component", input={"name": "Alice", "age": 25}
+            component="/test_component",
+            input={"name": "Alice", "age": 25},
+            step_id="test_step",
+            run_id="test-run-id",
+            flow_id="test-flow-id",
         ),
     )
     response = await server.handle_message(request)
@@ -240,7 +244,11 @@ async def test_handle_component_execute_invalid_input(server):
         id="test-1",
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="/test_component", input={"invalid": "input"}
+            component="/test_component",
+            input={"invalid": "input"},
+            step_id="test_step",
+            run_id="test-run-id",
+            flow_id="test-flow-id",
         ),
     )
 
@@ -321,7 +329,11 @@ async def test_component_execute_with_context(server):
         id="test-1",
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="/context_component", input={"name": "Alice", "age": 25}
+            component="/context_component",
+            input={"name": "Alice", "age": 25},
+            step_id="test_step",
+            run_id="test-run-id",
+            flow_id="test-flow-id",
         ),
     )
 
@@ -354,7 +366,11 @@ async def test_server_responses_include_jsonrpc(server):
         id="jsonrpc-test",
         method=Method.components_execute,
         params=ComponentExecuteParams(
-            component="/test_component", input={"name": "Test", "age": 30}
+            component="/test_component",
+            input={"name": "Test", "age": 30},
+            step_id="test_step",
+            run_id="test-run-id",
+            flow_id="test-flow-id",
         ),
     )
 
@@ -430,7 +446,11 @@ def test_requires_context():
                 id="test3",
                 method=Method.components_execute,
                 params=ComponentExecuteParams(
-                    component="/simple", input={"message": "test"}
+                    component="/simple",
+                    input={"message": "test"},
+                    step_id="test_step",
+                    run_id="test-run-id",
+                    flow_id="test-flow-id",
                 ),
             ),
             "expected": False,
@@ -443,7 +463,11 @@ def test_requires_context():
                 id="test4",
                 method=Method.components_execute,
                 params=ComponentExecuteParams(
-                    component="/context", input={"message": "test"}
+                    component="/context",
+                    input={"message": "test"},
+                    step_id="test_step",
+                    run_id="test-run-id",
+                    flow_id="test-flow-id",
                 ),
             ),
             "expected": True,
@@ -456,7 +480,11 @@ def test_requires_context():
                 id="test5",
                 method=Method.components_execute,
                 params=ComponentExecuteParams(
-                    component="/nonexistent", input={"message": "test"}
+                    component="/nonexistent",
+                    input={"message": "test"},
+                    step_id="test_step",
+                    run_id="test-run-id",
+                    flow_id="test-flow-id",
                 ),
             ),
             "expected": False,

--- a/stepflow-rs/crates/stepflow-analysis/src/dependency.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/dependency.rs
@@ -207,6 +207,7 @@ mod tests {
             output_schema: None,
             skip_if: None,
             on_error: ErrorAction::Fail,
+            metadata: std::collections::HashMap::new(),
         }
     }
 
@@ -226,6 +227,7 @@ mod tests {
                     output_schema: None,
                     skip_if: None,
                     on_error: ErrorAction::Fail,
+                    metadata: std::collections::HashMap::new(),
                 },
                 Step {
                     id: "step2".to_string(),
@@ -235,11 +237,13 @@ mod tests {
                     output_schema: None,
                     skip_if: None,
                     on_error: ErrorAction::Fail,
+                    metadata: std::collections::HashMap::new(),
                 },
             ],
             output: ValueTemplate::step_ref("step2", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         })
     }
 
@@ -438,6 +442,7 @@ mod tests {
             output: ValueTemplate::step_ref("step1", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let result = analyze_flow_dependencies(

--- a/stepflow-rs/crates/stepflow-analysis/src/validation.rs
+++ b/stepflow-rs/crates/stepflow-analysis/src/validation.rs
@@ -371,6 +371,7 @@ mod tests {
             output_schema: None,
             skip_if: None,
             on_error: ErrorAction::Fail,
+            metadata: std::collections::HashMap::new(),
         }
     }
 
@@ -389,6 +390,7 @@ mod tests {
             output: ValueTemplate::step_ref("step2", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();
@@ -411,6 +413,7 @@ mod tests {
             output: ValueTemplate::step_ref("step2", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();
@@ -439,6 +442,7 @@ mod tests {
             output: ValueTemplate::step_ref("step1", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();
@@ -467,6 +471,7 @@ mod tests {
             output: ValueTemplate::step_ref("step1", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();
@@ -495,6 +500,7 @@ mod tests {
             output: ValueTemplate::step_ref("step1", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();
@@ -523,6 +529,7 @@ mod tests {
             output: ValueTemplate::step_ref("step1", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();
@@ -559,10 +566,12 @@ mod tests {
                 output_schema: None,
                 skip_if: None,
                 on_error: ErrorAction::Fail,
+                metadata: std::collections::HashMap::new(),
             }],
             output: ValueTemplate::step_ref("step1", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();
@@ -593,10 +602,12 @@ mod tests {
                 output_schema: None,
                 skip_if: None,
                 on_error: ErrorAction::Fail,
+                metadata: std::collections::HashMap::new(),
             }],
             output: ValueTemplate::step_ref("step1", JsonPath::default()),
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
 
         let diagnostics = validate_workflow(&flow).unwrap();

--- a/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
@@ -88,21 +88,4 @@ impl stepflow_plugin::Context for MockExecutor {
     fn working_directory(&self) -> &std::path::Path {
         Path::new(".")
     }
-
-    fn get_execution_metadata(
-        &self,
-        _step_id: Option<&str>,
-    ) -> Pin<
-        Box<
-            dyn std::future::Future<
-                    Output = stepflow_plugin::Result<stepflow_plugin::ExecutionMetadata>,
-                > + Send
-                + '_,
-        >,
-    > {
-        Box::pin(async move {
-            // Return empty metadata for tests
-            Ok(stepflow_plugin::ExecutionMetadata::empty())
-        })
-    }
 }

--- a/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
+++ b/stepflow-rs/crates/stepflow-builtins/src/mock_context.rs
@@ -41,7 +41,11 @@ impl MockContext {
 
     /// Get an execution context for testing from this mock context.
     pub fn execution_context(&self) -> ExecutionContext {
-        ExecutionContext::new(self.executor.clone(), Uuid::new_v4())
+        ExecutionContext::new(
+            self.executor.clone(),
+            Uuid::new_v4(),
+            Some("test_step".to_string()),
+        )
     }
 }
 
@@ -83,5 +87,22 @@ impl stepflow_plugin::Context for MockExecutor {
 
     fn working_directory(&self) -> &std::path::Path {
         Path::new(".")
+    }
+
+    fn get_execution_metadata(
+        &self,
+        _step_id: Option<&str>,
+    ) -> Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = stepflow_plugin::Result<stepflow_plugin::ExecutionMetadata>,
+                > + Send
+                + '_,
+        >,
+    > {
+        Box::pin(async move {
+            // Return empty metadata for tests
+            Ok(stepflow_plugin::ExecutionMetadata::empty())
+        })
     }
 }

--- a/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
@@ -50,15 +50,6 @@ fn create_test_context() -> (Arc<dyn stepflow_plugin::Context>, ExecutionContext
         fn working_directory(&self) -> &std::path::Path {
             std::path::Path::new(".")
         }
-        fn get_execution_metadata(
-            &self,
-            _step_id: Option<&str>,
-        ) -> futures::future::BoxFuture<
-            '_,
-            stepflow_plugin::Result<stepflow_plugin::ExecutionMetadata>,
-        > {
-            async move { Ok(stepflow_plugin::ExecutionMetadata::empty()) }.boxed()
-        }
     }
 
     let test_context = Arc::new(TestContext {

--- a/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
+++ b/stepflow-rs/crates/stepflow-components-mcp/tests/integration_test.rs
@@ -50,12 +50,25 @@ fn create_test_context() -> (Arc<dyn stepflow_plugin::Context>, ExecutionContext
         fn working_directory(&self) -> &std::path::Path {
             std::path::Path::new(".")
         }
+        fn get_execution_metadata(
+            &self,
+            _step_id: Option<&str>,
+        ) -> futures::future::BoxFuture<
+            '_,
+            stepflow_plugin::Result<stepflow_plugin::ExecutionMetadata>,
+        > {
+            async move { Ok(stepflow_plugin::ExecutionMetadata::empty()) }.boxed()
+        }
     }
 
     let test_context = Arc::new(TestContext {
         state_store: Arc::new(InMemoryStateStore::new()),
     });
-    let exec_context = ExecutionContext::new(test_context.clone(), Uuid::new_v4());
+    let exec_context = ExecutionContext::new(
+        test_context.clone(),
+        Uuid::new_v4(),
+        Some("test_step".to_string()),
+    );
 
     (test_context, exec_context)
 }

--- a/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
+++ b/stepflow-rs/crates/stepflow-core/src/values/value_resolver.rs
@@ -332,10 +332,12 @@ mod tests {
                 output_schema: None,
                 skip_if: None,
                 on_error: ErrorAction::Fail,
+                metadata: HashMap::default(),
             }],
             output: ValueTemplate::literal(json!(null)),
             test: None,
             examples: None,
+            metadata: HashMap::default(),
         }))
     }
 

--- a/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
@@ -69,6 +69,12 @@ impl Flow {
         }
     }
 
+    pub fn version(&self) -> Option<&str> {
+        match self {
+            Flow::V1(flow_v1) => flow_v1.version.as_deref(),
+        }
+    }
+
     pub fn metadata(&self) -> &HashMap<String, serde_json::Value> {
         match self {
             Flow::V1(flow_v1) => &flow_v1.metadata,

--- a/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/flow.rs
@@ -69,6 +69,12 @@ impl Flow {
         }
     }
 
+    pub fn metadata(&self) -> &HashMap<String, serde_json::Value> {
+        match self {
+            Flow::V1(flow_v1) => &flow_v1.metadata,
+        }
+    }
+
     /// Returns a reference to all steps in the flow.
     pub fn steps(&self) -> &[Step] {
         &self.latest().steps
@@ -175,6 +181,10 @@ pub struct FlowV1 {
     /// Example inputs for the workflow that can be used for testing and UI dropdowns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub examples: Option<Vec<ExampleInput>>,
+
+    /// Extensible metadata for the flow that can be used by tools and frameworks.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, serde_json::Value>,
 }
 
 /// A wrapper around `Arc<Flow>` to support poem-openapi traits.
@@ -501,6 +511,7 @@ mod tests {
                     output_schema: None,
                     skip_if: None,
                     on_error: ErrorAction::default(),
+                    metadata: HashMap::default(),
                 },
                 Step {
                     id: "s2".to_owned(),
@@ -512,6 +523,7 @@ mod tests {
                     output_schema: None,
                     skip_if: None,
                     on_error: ErrorAction::default(),
+                    metadata: HashMap::default(),
                 },
             ],
             output: ValueTemplate::parse_value(serde_json::json!({
@@ -521,6 +533,7 @@ mod tests {
             .unwrap(),
             test: None,
             examples: None,
+            metadata: HashMap::default(),
         };
 
         similar_asserts::assert_serde_eq!(latest, &expected_flow);
@@ -545,6 +558,7 @@ mod tests {
                 description: Some("Direct example".to_string()),
                 input: ValueRef::new(json!({"input": "example"})),
             }]),
+            metadata: HashMap::default(),
             test: Some(TestConfig {
                 config: None,
                 servers: HashMap::default(),

--- a/stepflow-rs/crates/stepflow-core/src/workflow/step.rs
+++ b/stepflow-rs/crates/stepflow-core/src/workflow/step.rs
@@ -11,6 +11,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
+use std::collections::HashMap;
+
 use super::{Component, Expr, ValueTemplate};
 use crate::schema::SchemaRef;
 use schemars::JsonSchema;
@@ -41,6 +43,10 @@ pub struct Step {
     /// Arguments to pass to the component for this step
     #[serde(default, skip_serializing_if = "ValueTemplate::is_null")]
     pub input: ValueTemplate,
+
+    /// Extensible metadata for the step that can be used by tools and frameworks.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, serde_json::Value>,
 }
 
 #[derive(
@@ -151,6 +157,7 @@ mod tests {
                 default_value: Some(ValueRef::from("fallback").into()),
             },
             input: ValueTemplate::null(),
+            metadata: HashMap::default(),
         };
 
         let yaml = serde_yaml_ng::to_string(&step).unwrap();
@@ -169,6 +176,7 @@ mod tests {
             skip_if: None,
             on_error: ErrorAction::Fail,
             input: ValueTemplate::null(),
+            metadata: HashMap::default(),
         };
 
         let yaml = serde_yaml_ng::to_string(&step).unwrap();

--- a/stepflow-rs/crates/stepflow-execution/src/executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/executor.rs
@@ -96,8 +96,8 @@ impl StepflowExecutor {
         }
     }
 
-    pub fn execution_context(&self, run_id: Uuid) -> ExecutionContext {
-        ExecutionContext::new(self.executor(), run_id)
+    pub fn execution_context(&self, run_id: Uuid, step_id: String) -> ExecutionContext {
+        ExecutionContext::for_step(self.executor(), run_id, step_id)
     }
 
     /// Get a reference to the state store.
@@ -292,6 +292,18 @@ impl Context for StepflowExecutor {
 
     fn working_directory(&self) -> &std::path::Path {
         &self.working_directory
+    }
+
+    fn get_execution_metadata(
+        &self,
+        _step_id: Option<&str>,
+    ) -> BoxFuture<'_, stepflow_plugin::Result<stepflow_plugin::ExecutionMetadata>> {
+        async move {
+            // For now, return empty metadata as the StepflowExecutor doesn't have access to current execution context
+            // This will be properly implemented when we have execution-specific contexts
+            Ok(stepflow_plugin::ExecutionMetadata::empty())
+        }
+        .boxed()
     }
 }
 

--- a/stepflow-rs/crates/stepflow-execution/src/executor.rs
+++ b/stepflow-rs/crates/stepflow-execution/src/executor.rs
@@ -293,18 +293,6 @@ impl Context for StepflowExecutor {
     fn working_directory(&self) -> &std::path::Path {
         &self.working_directory
     }
-
-    fn get_execution_metadata(
-        &self,
-        _step_id: Option<&str>,
-    ) -> BoxFuture<'_, stepflow_plugin::Result<stepflow_plugin::ExecutionMetadata>> {
-        async move {
-            // For now, return empty metadata as the StepflowExecutor doesn't have access to current execution context
-            // This will be properly implemented when we have execution-specific contexts
-            Ok(stepflow_plugin::ExecutionMetadata::empty())
-        }
-        .boxed()
-    }
 }
 
 #[cfg(test)]

--- a/stepflow-rs/crates/stepflow-plugin/src/context.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/context.rs
@@ -317,9 +317,7 @@ impl Context for ExecutionContext {
         // If we have a flow, provide metadata; otherwise delegate to underlying context
         if let Some(flow) = &self.flow {
             // Use provided step_id or fall back to the context's current step_id, convert to owned
-            let target_step_id = step_id
-                .map(|s| s.to_string())
-                .or_else(|| self.step_id().map(|s| s.to_string()));
+            let target_step_id = step_id.map(|s| s.to_string());
             let flow = flow.clone();
 
             async move {
@@ -341,11 +339,11 @@ impl Context for ExecutionContext {
                         serde_json::Value::String(description.to_string()),
                     );
                 }
-                // Note: Flow doesn't have a version method, but FlowV1 has a version field
-                if let Some(version) = flow.latest().version.as_ref() {
+
+                if let Some(version) = flow.version() {
                     flow_metadata.insert(
                         "version".to_string(),
-                        serde_json::Value::String(version.clone()),
+                        serde_json::Value::String(version.to_string()),
                     );
                 }
 

--- a/stepflow-rs/crates/stepflow-plugin/src/error.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/error.rs
@@ -11,6 +11,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
+use std::borrow::Cow;
+
 use stepflow_core::workflow::Component;
 use thiserror::Error;
 
@@ -44,6 +46,8 @@ pub enum PluginError {
     InvalidRuleIndex(usize),
     #[error("plugin not found: {0}")]
     PluginNotFound(String),
+    #[error("internal error: {0}")]
+    Internal(Cow<'static, str>),
 }
 
 pub type Result<T, E = error_stack::Report<PluginError>> = std::result::Result<T, E>;

--- a/stepflow-rs/crates/stepflow-plugin/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/lib.rs
@@ -16,6 +16,6 @@ mod error;
 mod plugin;
 pub mod routing;
 
-pub use context::{Context, ExecutionContext, ExecutionMetadata};
+pub use context::{Context, ExecutionContext};
 pub use error::{PluginError, Result};
 pub use plugin::{DynPlugin, Plugin, PluginConfig};

--- a/stepflow-rs/crates/stepflow-plugin/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-plugin/src/lib.rs
@@ -16,6 +16,6 @@ mod error;
 mod plugin;
 pub mod routing;
 
-pub use context::{Context, ExecutionContext};
+pub use context::{Context, ExecutionContext, ExecutionMetadata};
 pub use error::{PluginError, Result};
 pub use plugin::{DynPlugin, Plugin, PluginConfig};

--- a/stepflow-rs/crates/stepflow-protocol/src/error.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/error.rs
@@ -56,6 +56,11 @@ pub enum TransportError {
     MethodMissingId { method: Cow<'static, str> },
     #[error("invalid environment variable: {0}")]
     InvalidEnvironmentVariable(String),
+    #[error("invalid value for field '{field}': expected {expected}")]
+    InvalidValue {
+        field: &'static str,
+        expected: &'static str,
+    },
 }
 
 pub type Result<T, E = error_stack::Report<TransportError>> = std::result::Result<T, E>;

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/flow_handlers.rs
@@ -74,14 +74,14 @@ impl MethodHandler for GetFlowMetadataHandler {
                     // Parse the string UUID
                     let run_id = run_id_str
                         .parse::<uuid::Uuid>()
-                        .map_err(|_| Error::internal("Invalid run_id format"))?;
+                        .map_err(|_| Error::internal("Invalid run_id format: expected UUID"))?;
 
                     // Fetch the flow from the state store
-                    let blob_data = context.state_store().get_blob(flow_id).await.map_err(|e| {
-                        tracing::error!("Failed to get blob: {e}");
-                        Error::internal("Failed to get blob")
-                    })?;
-
+                    let blob_data = context
+                        .state_store()
+                        .get_blob(flow_id)
+                        .await
+                        .change_context(Error::internal("Failed to get flow blob"))?;
                     let flow = blob_data
                         .as_flow()
                         .ok_or_else(|| Error::internal("Invalid flow blob"))?

--- a/stepflow-rs/crates/stepflow-protocol/src/handlers/message_handler.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/handlers/message_handler.rs
@@ -18,7 +18,7 @@ use stepflow_plugin::Context;
 use tokio::sync::mpsc;
 
 use super::blob_handlers::{GetBlobHandler, PutBlobHandler};
-use super::flow_handlers::EvaluateFlowHandler;
+use super::flow_handlers::{EvaluateFlowHandler, GetFlowMetadataHandler};
 use crate::error::TransportError;
 use crate::protocol::{Method, MethodRequest};
 
@@ -55,6 +55,7 @@ static INCOMING_HANDLERS: LazyLock<MessageHandlerRegistry> = LazyLock::new(|| {
     registry.register_method(Method::BlobsGet, Box::new(GetBlobHandler));
     registry.register_method(Method::BlobsPut, Box::new(PutBlobHandler));
     registry.register_method(Method::FlowsEvaluate, Box::new(EvaluateFlowHandler));
+    registry.register_method(Method::FlowsGetMetadata, Box::new(GetFlowMetadataHandler));
     registry
 });
 

--- a/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
@@ -481,6 +481,13 @@ mod tests {
         fn working_directory(&self) -> &Path {
             Path::new("/tmp")
         }
+
+        fn get_execution_metadata(
+            &self,
+            _step_id: Option<&str>,
+        ) -> BoxFuture<'_, PluginResult<stepflow_plugin::ExecutionMetadata>> {
+            async move { Ok(stepflow_plugin::ExecutionMetadata::empty()) }.boxed()
+        }
     }
 
     #[tokio::test]

--- a/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/http/client.rs
@@ -481,13 +481,6 @@ mod tests {
         fn working_directory(&self) -> &Path {
             Path::new("/tmp")
         }
-
-        fn get_execution_metadata(
-            &self,
-            _step_id: Option<&str>,
-        ) -> BoxFuture<'_, PluginResult<stepflow_plugin::ExecutionMetadata>> {
-            async move { Ok(stepflow_plugin::ExecutionMetadata::empty()) }.boxed()
-        }
     }
 
     #[tokio::test]

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/components.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/components.rs
@@ -27,6 +27,12 @@ pub struct ComponentExecuteParams {
     pub component: Component,
     /// The input to the component.
     pub input: ValueRef,
+    /// The ID of the step being executed.
+    pub step_id: String,
+    /// The ID of the workflow run.
+    pub run_id: String,
+    /// The ID of the flow being executed.
+    pub flow_id: stepflow_core::BlobId,
 }
 
 /// Sent from the component server back to Stepflow with the result of the component execution.

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
@@ -50,6 +50,9 @@ impl ProtocolMethod for EvaluateFlowParams {
 /// YAML/JSON.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct GetFlowMetadataParams {
+    /// The flow to retrieve metadata for.
+    pub flow_id: BlobId,
+
     /// The ID of the step to get metadata for (optional).
     ///
     /// If not provided, only flow-level metadata is returned.
@@ -57,18 +60,6 @@ pub struct GetFlowMetadataParams {
     /// If the step_id doesn't exist, step_metadata will be None in the response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step_id: Option<String>,
-
-    /// The execution run ID for the current workflow execution.
-    ///
-    /// This allows the handler to construct the proper execution context for metadata lookup.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub run_id: Option<String>,
-
-    /// The flow blob ID for the current workflow.
-    ///
-    /// This allows the handler to construct the proper execution context for metadata lookup.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub flow_id: Option<BlobId>,
 }
 
 /// Sent from Stepflow back to the component server with the requested metadata.

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/flows.rs
@@ -11,6 +11,8 @@
 // or implied.  See the License for the specific language governing permissions and limitations under
 // the License.
 
+use std::collections::HashMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use stepflow_core::workflow::ValueRef;
@@ -39,4 +41,59 @@ pub struct EvaluateFlowResult {
 impl ProtocolMethod for EvaluateFlowParams {
     const METHOD_NAME: Method = Method::FlowsEvaluate;
     type Response = EvaluateFlowResult;
+}
+
+/// Sent from the component server to Stepflow to get flow and step metadata.
+///
+/// This request allows components to access workflow-level metadata and step-specific metadata
+/// during execution. The metadata can contain arbitrary JSON values defined in the workflow
+/// YAML/JSON.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct GetFlowMetadataParams {
+    /// The ID of the step to get metadata for (optional).
+    ///
+    /// If not provided, only flow-level metadata is returned.
+    /// If provided, both flow metadata and the specified step's metadata are returned.
+    /// If the step_id doesn't exist, step_metadata will be None in the response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
+
+    /// The execution run ID for the current workflow execution.
+    ///
+    /// This allows the handler to construct the proper execution context for metadata lookup.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+
+    /// The flow blob ID for the current workflow.
+    ///
+    /// This allows the handler to construct the proper execution context for metadata lookup.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flow_id: Option<BlobId>,
+}
+
+/// Sent from Stepflow back to the component server with the requested metadata.
+///
+/// Contains the flow metadata and step metadata if a specific step was requested.
+/// The metadata values are arbitrary JSON objects that can be accessed by components during
+/// workflow execution.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct GetFlowMetadataResult {
+    /// Metadata for the current flow.
+    ///
+    /// This always contains the flow-level metadata defined in the workflow file.
+    /// Common fields include name, description, version, but can contain any
+    /// arbitrary JSON structure defined by the workflow author.
+    pub flow_metadata: HashMap<String, serde_json::Value>,
+
+    /// Metadata for the specified step (only present if step_id was provided and found).
+    ///
+    /// This contains step-specific metadata defined in the workflow file.
+    /// Will be None if no step_id was provided in the request
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_metadata: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl ProtocolMethod for GetFlowMetadataParams {
+    const METHOD_NAME: Method = Method::FlowsGetMetadata;
+    type Response = GetFlowMetadataResult;
 }

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/messages.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/messages.rs
@@ -154,6 +154,22 @@ impl<'a> Error<'a> {
             data: None,
         }
     }
+
+    pub fn invalid_value(field: &str, expected: &str) -> Self {
+        Error {
+            code: -32012,
+            message: format!("Invalid value for field '{field}': expected {expected}").into(),
+            data: None,
+        }
+    }
+
+    pub fn not_found(entity: &str, id: &str) -> Self {
+        Error {
+            code: -32011,
+            message: format!("Not found: {entity} with ID '{id}'").into(),
+            data: None,
+        }
+    }
 }
 
 /// Request to execute a method.

--- a/stepflow-rs/crates/stepflow-protocol/src/protocol/methods.rs
+++ b/stepflow-rs/crates/stepflow-protocol/src/protocol/methods.rs
@@ -32,6 +32,8 @@ pub enum Method {
     BlobsGet,
     #[serde(rename = "flows/evaluate")]
     FlowsEvaluate,
+    #[serde(rename = "flows/get_metadata")]
+    FlowsGetMetadata,
 }
 
 impl std::fmt::Display for Method {
@@ -45,6 +47,7 @@ impl std::fmt::Display for Method {
             Method::BlobsPut => write!(f, "blobs/put"),
             Method::BlobsGet => write!(f, "blobs/get"),
             Method::FlowsEvaluate => write!(f, "flows/evaluate"),
+            Method::FlowsGetMetadata => write!(f, "flows/get_metadata"),
         }
     }
 }
@@ -67,6 +70,7 @@ pub(crate) fn method_params(generator: &mut schemars::SchemaGenerator) -> Schema
         generator.subschema_for::<super::blobs::GetBlobParams>(),
         generator.subschema_for::<super::blobs::PutBlobParams>(),
         generator.subschema_for::<super::flows::EvaluateFlowParams>(),
+        generator.subschema_for::<super::flows::GetFlowMetadataParams>(),
     ];
     json_schema!({
         "title": "MethodParams",
@@ -84,6 +88,7 @@ pub(crate) fn method_result(generator: &mut schemars::SchemaGenerator) -> Schema
         generator.subschema_for::<super::blobs::GetBlobResult>(),
         generator.subschema_for::<super::blobs::PutBlobResult>(),
         generator.subschema_for::<super::flows::EvaluateFlowResult>(),
+        generator.subschema_for::<super::flows::GetFlowMetadataResult>(),
     ];
     json_schema!({
         "title": "MethodResult",
@@ -119,6 +124,10 @@ mod tests {
             serde_json::to_string(&Method::FlowsEvaluate).unwrap(),
             r#""flows/evaluate""#
         );
+        assert_eq!(
+            serde_json::to_string(&Method::FlowsGetMetadata).unwrap(),
+            r#""flows/get_metadata""#
+        );
     }
 
     #[test]
@@ -134,6 +143,10 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<Method>(r#""flows/evaluate""#).unwrap(),
             Method::FlowsEvaluate
+        );
+        assert_eq!(
+            serde_json::from_str::<Method>(r#""flows/get_metadata""#).unwrap(),
+            Method::FlowsGetMetadata
         );
     }
 

--- a/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
+++ b/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
@@ -70,22 +70,6 @@ impl Context for MockContext {
     {
         Box::pin(async { Err(PluginError::Execution.into()) })
     }
-
-    fn get_execution_metadata(
-        &self,
-        _step_id: Option<&str>,
-    ) -> Pin<
-        Box<
-            dyn Future<
-                    Output = Result<
-                        stepflow_plugin::ExecutionMetadata,
-                        error_stack::Report<PluginError>,
-                    >,
-                > + Send,
-        >,
-    > {
-        Box::pin(async move { Ok(stepflow_plugin::ExecutionMetadata::empty()) })
-    }
 }
 
 /// Test that we can create an HTTP plugin and it fails gracefully when no server is running

--- a/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
+++ b/stepflow-rs/crates/stepflow-protocol/tests/http_integration_test.rs
@@ -70,6 +70,22 @@ impl Context for MockContext {
     {
         Box::pin(async { Err(PluginError::Execution.into()) })
     }
+
+    fn get_execution_metadata(
+        &self,
+        _step_id: Option<&str>,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<
+                        stepflow_plugin::ExecutionMetadata,
+                        error_stack::Report<PluginError>,
+                    >,
+                > + Send,
+        >,
+    > {
+        Box::pin(async move { Ok(stepflow_plugin::ExecutionMetadata::empty()) })
+    }
 }
 
 /// Test that we can create an HTTP plugin and it fails gracefully when no server is running
@@ -192,8 +208,11 @@ async fn test_http_protocol_integration() {
                                 });
                                 let input_ref = ValueRef::from(input_json);
 
-                                let execution_context =
-                                    ExecutionContext::new(context.clone(), Uuid::new_v4());
+                                let execution_context = ExecutionContext::for_step(
+                                    context.clone(),
+                                    Uuid::new_v4(),
+                                    "test_step".to_string(),
+                                );
 
                                 let execute_result = timeout(
                                     Duration::from_secs(5),

--- a/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
+++ b/stepflow-rs/crates/stepflow-server/tests/integration_tests.rs
@@ -182,10 +182,12 @@ fn create_test_workflow() -> Flow {
             output_schema: None,
             skip_if: None,
             on_error: ErrorAction::Fail,
+            metadata: std::collections::HashMap::new(),
         }],
         output: ValueTemplate::default(),
         test: None,
         examples: None,
+        metadata: std::collections::HashMap::new(),
     })
 }
 
@@ -564,6 +566,7 @@ async fn test_status_updates_during_regular_execution() {
                 output_schema: None,
                 skip_if: None,
                 on_error: ErrorAction::Fail,
+                metadata: std::collections::HashMap::new(),
             },
             Step {
                 id: "step2".to_string(),
@@ -579,6 +582,7 @@ async fn test_status_updates_during_regular_execution() {
                 output_schema: None,
                 skip_if: None,
                 on_error: ErrorAction::Fail,
+                metadata: std::collections::HashMap::new(),
             },
         ],
         output: ValueTemplate::parse_value(json!({
@@ -588,6 +592,7 @@ async fn test_status_updates_during_regular_execution() {
         .unwrap(),
         test: None,
         examples: None,
+        metadata: std::collections::HashMap::new(),
     });
 
     // Store the workflow
@@ -687,6 +692,7 @@ async fn test_status_updates_during_debug_execution() {
                 output_schema: None,
                 skip_if: None,
                 on_error: ErrorAction::Fail,
+                metadata: std::collections::HashMap::new(),
             },
             Step {
                 id: "step2".to_string(),
@@ -702,6 +708,7 @@ async fn test_status_updates_during_debug_execution() {
                 output_schema: None,
                 skip_if: None,
                 on_error: ErrorAction::Fail,
+                metadata: std::collections::HashMap::new(),
             },
         ],
         output: ValueTemplate::parse_value(json!({
@@ -710,6 +717,7 @@ async fn test_status_updates_during_debug_execution() {
         .unwrap(),
         test: None,
         examples: None,
+        metadata: std::collections::HashMap::new(),
     });
 
     // Store the workflow
@@ -824,6 +832,7 @@ async fn test_status_transitions_with_error_handling() {
             output_schema: None,
             skip_if: None,
             on_error: ErrorAction::Fail,
+            metadata: std::collections::HashMap::new(),
         }],
         output: ValueTemplate::parse_value(json!({
             "result": {"$from": {"step": "failing_step"}, "path": "output"}
@@ -831,6 +840,7 @@ async fn test_status_transitions_with_error_handling() {
         .unwrap(),
         test: None,
         examples: None,
+        metadata: std::collections::HashMap::new(),
     });
 
     // Store the workflow

--- a/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
+++ b/stepflow-rs/crates/stepflow-state-sql/src/lib.rs
@@ -71,10 +71,12 @@ mod tests {
                 output_schema: None,
                 skip_if: None,
                 on_error: stepflow_core::workflow::ErrorAction::Fail,
+                metadata: std::collections::HashMap::new(),
             }],
             version: None,
             test: None,
             examples: None,
+            metadata: std::collections::HashMap::new(),
         });
         let flow_arc = std::sync::Arc::new(flow);
         let flow_data = ValueRef::new(serde_json::to_value(flow_arc.as_ref()).unwrap());

--- a/tests/python/simple_metadata_test.yaml
+++ b/tests/python/simple_metadata_test.yaml
@@ -1,5 +1,5 @@
 schema: https://stepflow.org/schemas/v1/flow.json
-name: Simple Metadata Test  
+name: Simple Metadata Test
 description: Test flow and step metadata access
 version: 1.0.0
 metadata:
@@ -29,14 +29,14 @@ steps:
           async def get_metadata_info(input, context):
             # Get metadata for current step (context will provide the step_id automatically)
             metadata_result = await context.get_metadata()
-            
+
             return {
               'input_message': input['message'],
               'flow_metadata': metadata_result.get('flow_metadata', {}),
               'step_metadata': metadata_result.get('step_metadata'),
               'context_step_id': context.step_id
             }
-          
+
           get_metadata_info
       blob_type: data
 
@@ -57,7 +57,7 @@ steps:
             workflow: input
           path: message
 
-  # Execute the UDF with second step metadata  
+  # Execute the UDF with second step metadata
   - id: second_metadata_step
     component: /python/udf
     metadata:
@@ -94,9 +94,6 @@ test:
           first_step_result:
             input_message: "test-input"
             flow_metadata:
-              name: Simple Metadata Test
-              description: Test flow and step metadata access
-              version: 1.0.0
               flow_type: test_workflow
             step_metadata:
               step_purpose: first_execution
@@ -105,9 +102,6 @@ test:
           second_step_result:
             input_message: "test-input"
             flow_metadata:
-              name: Simple Metadata Test
-              description: Test flow and step metadata access
-              version: 1.0.0
               flow_type: test_workflow
             step_metadata:
               step_purpose: second_execution

--- a/tests/python/simple_metadata_test.yaml
+++ b/tests/python/simple_metadata_test.yaml
@@ -1,0 +1,116 @@
+schema: https://stepflow.org/schemas/v1/flow.json
+name: Simple Metadata Test  
+description: Test flow and step metadata access
+version: 1.0.0
+metadata:
+  flow_type: test_workflow
+
+input_schema:
+  type: object
+  properties:
+    message:
+      type: string
+      default: hello
+
+steps:
+  # Create a UDF that returns both flow metadata and current step metadata
+  - id: create_metadata_reader
+    component: /builtin/put_blob
+    metadata:
+      step_purpose: udf_creation
+    input:
+      data:
+        input_schema:
+          type: object
+          properties:
+            message:
+              type: string
+        code: |
+          async def get_metadata_info(input, context):
+            # Get metadata for current step (context will provide the step_id automatically)
+            metadata_result = await context.get_metadata()
+            
+            return {
+              'input_message': input['message'],
+              'flow_metadata': metadata_result.get('flow_metadata', {}),
+              'step_metadata': metadata_result.get('step_metadata'),
+              'context_step_id': context.step_id
+            }
+          
+          get_metadata_info
+      blob_type: data
+
+  # Execute the UDF with first step metadata
+  - id: first_metadata_step
+    component: /python/udf
+    metadata:
+      step_purpose: first_execution
+      execution_order: 1
+    input:
+      blob_id:
+        $from:
+          step: create_metadata_reader
+        path: blob_id
+      input:
+        message:
+          $from:
+            workflow: input
+          path: message
+
+  # Execute the UDF with second step metadata  
+  - id: second_metadata_step
+    component: /python/udf
+    metadata:
+      step_purpose: second_execution
+      execution_order: 2
+      extra_info: additional_data
+    input:
+      blob_id:
+        $from:
+          step: create_metadata_reader
+        path: blob_id
+      input:
+        message:
+          $from:
+            workflow: input
+          path: message
+
+output:
+  first_step_result:
+    $from:
+      step: first_metadata_step
+  second_step_result:
+    $from:
+      step: second_metadata_step
+
+test:
+  cases:
+    - name: simple metadata access test
+      input:
+        message: "test-input"
+      output:
+        outcome: success
+        result:
+          first_step_result:
+            input_message: "test-input"
+            flow_metadata:
+              name: Simple Metadata Test
+              description: Test flow and step metadata access
+              version: 1.0.0
+              flow_type: test_workflow
+            step_metadata:
+              step_purpose: first_execution
+              execution_order: 1
+            context_step_id: first_metadata_step
+          second_step_result:
+            input_message: "test-input"
+            flow_metadata:
+              name: Simple Metadata Test
+              description: Test flow and step metadata access
+              version: 1.0.0
+              flow_type: test_workflow
+            step_metadata:
+              step_purpose: second_execution
+              execution_order: 2
+              extra_info: additional_data
+            context_step_id: second_metadata_step


### PR DESCRIPTION
Add comprehensive metadata system allowing flows to contain custom metadata at both flow and step levels, accessible by components during execution through the flows/get_metadata protocol method.

- Add metadata fields to Flow and Step types in stepflow-core
- Implement ExecutionMetadata type with flow and step metadata access
- Add flows/get_metadata protocol method and handlers
- Update ExecutionContext to support metadata retrieval

This enables components to access workflow-defined metadata for configuration, debugging, and runtime behavior customization.